### PR TITLE
traits/light: support presets

### DIFF
--- a/pkg/trait/light/model.go
+++ b/pkg/trait/light/model.go
@@ -10,12 +10,14 @@ import (
 
 type Model struct {
 	brightness *resource.Value
+	presets    []preset
 }
 
 func NewModel(opts ...resource.Option) *Model {
 	args := calcModelArgs(opts...)
 	return &Model{
 		brightness: resource.NewValue(args.brightnessOpts...),
+		presets:    args.presets,
 	}
 }
 
@@ -24,6 +26,9 @@ func (m *Model) GetBrightness(opts ...resource.ReadOption) (*traits.Brightness, 
 }
 
 func (m *Model) UpdateBrightness(light *traits.Brightness, opts ...resource.WriteOption) (*traits.Brightness, error) {
+	if m.setLevelFromPreset(light) {
+		opts = append(opts, resource.WithMoreUpdatePaths("level_percent"))
+	}
 	res, err := m.brightness.Set(light, opts...)
 	if err != nil {
 		return nil, err
@@ -49,7 +54,34 @@ func (m *Model) PullBrightness(ctx context.Context, opts ...resource.ReadOption)
 	return send
 }
 
+func (m *Model) ListPresets() []*traits.LightPreset {
+	var res []*traits.LightPreset
+	for _, p := range m.presets {
+		res = append(res, p.LightPreset)
+	}
+	return res
+}
+
+func (m *Model) setLevelFromPreset(b *traits.Brightness) bool {
+	if b.GetPreset() == nil {
+		return false
+	}
+	for _, p := range m.presets {
+		if p.Name == b.GetPreset().GetName() {
+			b.LevelPercent = p.levelPercent
+			b.Preset = p.LightPreset // sets the title if needed
+			return true
+		}
+	}
+	return false
+}
+
 type PullBrightnessChange struct {
 	Value      *traits.Brightness
 	ChangeTime time.Time
+}
+
+type preset struct {
+	*traits.LightPreset
+	levelPercent float32
 }

--- a/pkg/trait/light/model_opts.go
+++ b/pkg/trait/light/model_opts.go
@@ -28,6 +28,13 @@ func WithInitialBrightness(brightness *traits.Brightness) resource.Option {
 	return WithBrightnessOption(resource.WithInitialValue(brightness))
 }
 
+// WithPreset instructs the model to set the light to the given level when preset p is selected.
+func WithPreset(levelPercent float32, p *traits.LightPreset) resource.Option {
+	return modelOptionFunc(func(args *modelArgs) {
+		args.presets = append(args.presets, preset{p, levelPercent})
+	})
+}
+
 func calcModelArgs(opts ...resource.Option) modelArgs {
 	args := new(modelArgs)
 	args.apply(DefaultModelOptions...)
@@ -37,6 +44,7 @@ func calcModelArgs(opts ...resource.Option) modelArgs {
 
 type modelArgs struct {
 	brightnessOpts []resource.Option
+	presets        []preset
 }
 
 func (a *modelArgs) apply(opts ...resource.Option) {

--- a/pkg/trait/light/model_server.go
+++ b/pkg/trait/light/model_server.go
@@ -7,11 +7,13 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 type ModelServer struct {
 	traits.UnimplementedLightApiServer
+	traits.UnimplementedLightInfoServer
 	model *Model
 }
 
@@ -27,6 +29,7 @@ func (s *ModelServer) Unwrap() any {
 
 func (s *ModelServer) Register(server *grpc.Server) {
 	traits.RegisterLightApiServer(server, s)
+	traits.RegisterLightInfoServer(server, s)
 }
 
 func (s *ModelServer) GetBrightness(_ context.Context, req *traits.GetBrightnessRequest) (*traits.Brightness, error) {
@@ -54,4 +57,15 @@ func (s *ModelServer) PullBrightness(request *traits.PullBrightnessRequest, serv
 	}
 
 	return server.Context().Err()
+}
+
+func (s *ModelServer) DescribeBrightness(_ context.Context, _ *traits.DescribeBrightnessRequest) (*traits.BrightnessSupport, error) {
+	support := &traits.BrightnessSupport{
+		ResourceSupport: &types.ResourceSupport{
+			Readable: true, Writable: true, Observable: true,
+			PullSupport: types.PullSupport_PULL_SUPPORT_NATIVE,
+		},
+		Presets: s.model.ListPresets(),
+	}
+	return support, nil
 }


### PR DESCRIPTION
Add options and related functionality for the Model to adjust the levelPercent from a preset. Have the ModelServer implement LightInfo and return those presets when asked.