### PR TITLE
SC-597: fix race condition in wrapper stream

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,0 +1,24 @@
+name: Go Test
+on:
+  push:
+    branches: [main]
+
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Run tests
+      run: go test -v ./...
+
+    - name: Run short tests with race detector
+      run: go test -v -short -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smart-core-os/sc-golang
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/pkg/wrap/stream.go
+++ b/pkg/wrap/stream.go
@@ -101,7 +101,7 @@ func (c *clientStream) RecvMsg(m any) error {
 		//  1. if c.closed() was called by c.Close(...), then c.closeErr will be available
 		//  2. if the parent context was cancelled, then c.closeErr may not be available
 		select {
-		case _, ok := <-c.clientSend:
+		case _, ok := <-c.serverSend:
 			if !ok {
 				return c.closeErrLocked()
 			}


### PR DESCRIPTION
Logic error in `ClientServerStream` causes a race between `clientStream.RecvMsg` and `ClientServerStream.Close`.

Also fix a couple of tests that had inadequate synchronisation for collecting results.

Add CI tests.