### PR TITLE
server: use grpc.ServiceRegistrar instead of *grpc.Server

### DIFF
--- a/cmd/protoc-gen-router/router.go.gotxt
+++ b/cmd/protoc-gen-router/router.go.gotxt
@@ -29,7 +29,7 @@ func With{{.ClientName.Exported}}Factory(f func(name string) ({{.ClientName.Qual
   })
 }
 
-func (r *{{.RouterName}}) Register(server *grpc.Server) {
+func (r *{{.RouterName}}) Register(server grpc.ServiceRegistrar) {
 	{{.RegisterService.Qualified}}(server, r)
 }
 

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -3,12 +3,12 @@ package server
 import "google.golang.org/grpc"
 
 type GrpcApi interface {
-	Register(server *grpc.Server)
+	Register(server grpc.ServiceRegistrar)
 }
 
 type collection []GrpcApi
 
-func (c collection) Register(server *grpc.Server) {
+func (c collection) Register(server grpc.ServiceRegistrar) {
 	for _, api := range c {
 		api.Register(server)
 	}

--- a/pkg/trait/airqualitysensor/api_router.pb.go
+++ b/pkg/trait/airqualitysensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithAirQualitySensorApiClientFactory(f func(name string) (traits.AirQuality
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirQualitySensorApiServer(server, r)
 }
 

--- a/pkg/trait/airqualitysensor/info_router.pb.go
+++ b/pkg/trait/airqualitysensor/info_router.pb.go
@@ -34,7 +34,7 @@ func WithAirQualitySensorInfoClientFactory(f func(name string) (traits.AirQualit
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirQualitySensorInfoServer(server, r)
 }
 

--- a/pkg/trait/airqualitysensor/model_server.go
+++ b/pkg/trait/airqualitysensor/model_server.go
@@ -3,11 +3,13 @@ package airqualitysensor
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type ModelServer struct {
@@ -25,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirQualitySensorApiServer(server, s)
 }
 

--- a/pkg/trait/airtemperature/api_router.pb.go
+++ b/pkg/trait/airtemperature/api_router.pb.go
@@ -35,7 +35,7 @@ func WithAirTemperatureApiClientFactory(f func(name string) (traits.AirTemperatu
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureApiServer(server, r)
 }
 

--- a/pkg/trait/airtemperature/info_router.pb.go
+++ b/pkg/trait/airtemperature/info_router.pb.go
@@ -34,7 +34,7 @@ func WithAirTemperatureInfoClientFactory(f func(name string) (traits.AirTemperat
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureInfoServer(server, r)
 }
 

--- a/pkg/trait/airtemperature/memory.go
+++ b/pkg/trait/airtemperature/memory.go
@@ -3,11 +3,12 @@ package airtemperature
 import (
 	"context"
 
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-api/go/types"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type MemoryDevice struct {
@@ -39,7 +40,7 @@ func InitialAirTemperatureState() *traits.AirTemperature {
 	}
 }
 
-func (t *MemoryDevice) Register(server *grpc.Server) {
+func (t *MemoryDevice) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureApiServer(server, t)
 }
 

--- a/pkg/trait/airtemperature/model_server.go
+++ b/pkg/trait/airtemperature/model_server.go
@@ -3,11 +3,13 @@ package airtemperature
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type ModelServer struct {
@@ -25,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureApiServer(server, s)
 }
 

--- a/pkg/trait/booking/api_router.pb.go
+++ b/pkg/trait/booking/api_router.pb.go
@@ -35,7 +35,7 @@ func WithBookingApiClientFactory(f func(name string) (traits.BookingApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBookingApiServer(server, r)
 }
 

--- a/pkg/trait/booking/info_router.pb.go
+++ b/pkg/trait/booking/info_router.pb.go
@@ -34,7 +34,7 @@ func WithBookingInfoClientFactory(f func(name string) (traits.BookingInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBookingInfoServer(server, r)
 }
 

--- a/pkg/trait/booking/model_server.go
+++ b/pkg/trait/booking/model_server.go
@@ -3,14 +3,15 @@ package booking
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types/time"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
-	timepb "github.com/smart-core-os/sc-golang/pkg/time"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types/time"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+	timepb "github.com/smart-core-os/sc-golang/pkg/time"
 )
 
 type ModelServer struct {
@@ -27,7 +28,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBookingApiServer(server, m)
 }
 

--- a/pkg/trait/brightnesssensor/api_router.pb.go
+++ b/pkg/trait/brightnesssensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithBrightnessSensorApiClientFactory(f func(name string) (traits.Brightness
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBrightnessSensorApiServer(server, r)
 }
 

--- a/pkg/trait/brightnesssensor/info_router.pb.go
+++ b/pkg/trait/brightnesssensor/info_router.pb.go
@@ -34,7 +34,7 @@ func WithBrightnessSensorInfoClientFactory(f func(name string) (traits.Brightnes
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBrightnessSensorInfoServer(server, r)
 }
 

--- a/pkg/trait/channel/api_router.pb.go
+++ b/pkg/trait/channel/api_router.pb.go
@@ -35,7 +35,7 @@ func WithChannelApiClientFactory(f func(name string) (traits.ChannelApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterChannelApiServer(server, r)
 }
 

--- a/pkg/trait/channel/info_router.pb.go
+++ b/pkg/trait/channel/info_router.pb.go
@@ -34,7 +34,7 @@ func WithChannelInfoClientFactory(f func(name string) (traits.ChannelInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterChannelInfoServer(server, r)
 }
 

--- a/pkg/trait/count/api_router.pb.go
+++ b/pkg/trait/count/api_router.pb.go
@@ -35,7 +35,7 @@ func WithCountApiClientFactory(f func(name string) (traits.CountApiClient, error
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterCountApiServer(server, r)
 }
 

--- a/pkg/trait/count/info_router.pb.go
+++ b/pkg/trait/count/info_router.pb.go
@@ -34,7 +34,7 @@ func WithCountInfoClientFactory(f func(name string) (traits.CountInfoClient, err
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterCountInfoServer(server, r)
 }
 

--- a/pkg/trait/electric/api_router.pb.go
+++ b/pkg/trait/electric/api_router.pb.go
@@ -35,7 +35,7 @@ func WithElectricApiClientFactory(f func(name string) (traits.ElectricApiClient,
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterElectricApiServer(server, r)
 }
 

--- a/pkg/trait/electric/info_router.pb.go
+++ b/pkg/trait/electric/info_router.pb.go
@@ -33,7 +33,7 @@ func WithElectricInfoClientFactory(f func(name string) (traits.ElectricInfoClien
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterElectricInfoServer(server, r)
 }
 

--- a/pkg/trait/electric/memorysettingsapi_router.pb.go
+++ b/pkg/trait/electric/memorysettingsapi_router.pb.go
@@ -35,7 +35,7 @@ func WithMemorySettingsApiClientFactory(f func(name string) (MemorySettingsApiCl
 	})
 }
 
-func (r *MemorySettingsApiRouter) Register(server *grpc.Server) {
+func (r *MemorySettingsApiRouter) Register(server grpc.ServiceRegistrar) {
 	RegisterMemorySettingsApiServer(server, r)
 }
 

--- a/pkg/trait/electric/model_server.go
+++ b/pkg/trait/electric/model_server.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
 
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
@@ -32,7 +33,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterElectricApiServer(server, s)
 	RegisterMemorySettingsApiServer(server, s)
 }

--- a/pkg/trait/emergency/api_router.pb.go
+++ b/pkg/trait/emergency/api_router.pb.go
@@ -35,7 +35,7 @@ func WithEmergencyApiClientFactory(f func(name string) (traits.EmergencyApiClien
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEmergencyApiServer(server, r)
 }
 

--- a/pkg/trait/emergency/info_router.pb.go
+++ b/pkg/trait/emergency/info_router.pb.go
@@ -34,7 +34,7 @@ func WithEmergencyInfoClientFactory(f func(name string) (traits.EmergencyInfoCli
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEmergencyInfoServer(server, r)
 }
 

--- a/pkg/trait/emergency/memory.go
+++ b/pkg/trait/emergency/memory.go
@@ -3,12 +3,14 @@ package emergency
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type MemoryDevice struct {
@@ -29,7 +31,7 @@ func InitialEmergency() *traits.Emergency {
 	}
 }
 
-func (t *MemoryDevice) Register(server *grpc.Server) {
+func (t *MemoryDevice) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEmergencyApiServer(server, t)
 }
 

--- a/pkg/trait/energystorage/api_router.pb.go
+++ b/pkg/trait/energystorage/api_router.pb.go
@@ -35,7 +35,7 @@ func WithEnergyStorageApiClientFactory(f func(name string) (traits.EnergyStorage
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnergyStorageApiServer(server, r)
 }
 

--- a/pkg/trait/energystorage/info_router.pb.go
+++ b/pkg/trait/energystorage/info_router.pb.go
@@ -34,7 +34,7 @@ func WithEnergyStorageInfoClientFactory(f func(name string) (traits.EnergyStorag
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnergyStorageInfoServer(server, r)
 }
 

--- a/pkg/trait/energystorage/model_server.go
+++ b/pkg/trait/energystorage/model_server.go
@@ -3,12 +3,13 @@ package energystorage
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 type ModelServer struct {
@@ -31,7 +32,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnergyStorageApiServer(server, s)
 }
 

--- a/pkg/trait/enterleavesensor/api_router.pb.go
+++ b/pkg/trait/enterleavesensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithEnterLeaveSensorApiClientFactory(f func(name string) (traits.EnterLeave
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnterLeaveSensorApiServer(server, r)
 }
 

--- a/pkg/trait/enterleavesensor/info_router.pb.go
+++ b/pkg/trait/enterleavesensor/info_router.pb.go
@@ -33,7 +33,7 @@ func WithEnterLeaveSensorInfoClientFactory(f func(name string) (traits.EnterLeav
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnterLeaveSensorInfoServer(server, r)
 }
 

--- a/pkg/trait/enterleavesensor/model_server.go
+++ b/pkg/trait/enterleavesensor/model_server.go
@@ -24,7 +24,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnterLeaveSensorApiServer(server, m)
 }
 

--- a/pkg/trait/extendretract/api_router.pb.go
+++ b/pkg/trait/extendretract/api_router.pb.go
@@ -35,7 +35,7 @@ func WithExtendRetractApiClientFactory(f func(name string) (traits.ExtendRetract
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterExtendRetractApiServer(server, r)
 }
 

--- a/pkg/trait/extendretract/info_router.pb.go
+++ b/pkg/trait/extendretract/info_router.pb.go
@@ -34,7 +34,7 @@ func WithExtendRetractInfoClientFactory(f func(name string) (traits.ExtendRetrac
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterExtendRetractInfoServer(server, r)
 }
 

--- a/pkg/trait/fanspeed/api_router.pb.go
+++ b/pkg/trait/fanspeed/api_router.pb.go
@@ -35,7 +35,7 @@ func WithFanSpeedApiClientFactory(f func(name string) (traits.FanSpeedApiClient,
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterFanSpeedApiServer(server, r)
 }
 

--- a/pkg/trait/fanspeed/info_router.pb.go
+++ b/pkg/trait/fanspeed/info_router.pb.go
@@ -34,7 +34,7 @@ func WithFanSpeedInfoClientFactory(f func(name string) (traits.FanSpeedInfoClien
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterFanSpeedInfoServer(server, r)
 }
 

--- a/pkg/trait/fanspeed/model_server.go
+++ b/pkg/trait/fanspeed/model_server.go
@@ -3,11 +3,12 @@ package fanspeed
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model as a traits.FanSpeedApiServer.
@@ -24,7 +25,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterFanSpeedApiServer(server, s)
 }
 

--- a/pkg/trait/hail/api_router.pb.go
+++ b/pkg/trait/hail/api_router.pb.go
@@ -35,7 +35,7 @@ func WithHailApiClientFactory(f func(name string) (traits.HailApiClient, error))
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterHailApiServer(server, r)
 }
 

--- a/pkg/trait/hail/info_router.pb.go
+++ b/pkg/trait/hail/info_router.pb.go
@@ -33,7 +33,7 @@ func WithHailInfoClientFactory(f func(name string) (traits.HailInfoClient, error
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterHailInfoServer(server, r)
 }
 

--- a/pkg/trait/hail/model_server.go
+++ b/pkg/trait/hail/model_server.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model to implement traits.HailApiServer.
@@ -27,7 +28,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterHailApiServer(server, m)
 }
 

--- a/pkg/trait/inputselect/api_router.pb.go
+++ b/pkg/trait/inputselect/api_router.pb.go
@@ -35,7 +35,7 @@ func WithInputSelectApiClientFactory(f func(name string) (traits.InputSelectApiC
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterInputSelectApiServer(server, r)
 }
 

--- a/pkg/trait/inputselect/info_router.pb.go
+++ b/pkg/trait/inputselect/info_router.pb.go
@@ -34,7 +34,7 @@ func WithInputSelectInfoClientFactory(f func(name string) (traits.InputSelectInf
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterInputSelectInfoServer(server, r)
 }
 

--- a/pkg/trait/light/api_router.pb.go
+++ b/pkg/trait/light/api_router.pb.go
@@ -35,7 +35,7 @@ func WithLightApiClientFactory(f func(name string) (traits.LightApiClient, error
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLightApiServer(server, r)
 }
 

--- a/pkg/trait/light/info_router.pb.go
+++ b/pkg/trait/light/info_router.pb.go
@@ -34,7 +34,7 @@ func WithLightInfoClientFactory(f func(name string) (traits.LightInfoClient, err
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLightInfoServer(server, r)
 }
 

--- a/pkg/trait/light/model_server.go
+++ b/pkg/trait/light/model_server.go
@@ -27,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLightApiServer(server, s)
 	traits.RegisterLightInfoServer(server, s)
 }

--- a/pkg/trait/lockunlock/api_router.pb.go
+++ b/pkg/trait/lockunlock/api_router.pb.go
@@ -35,7 +35,7 @@ func WithLockUnlockApiClientFactory(f func(name string) (traits.LockUnlockApiCli
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLockUnlockApiServer(server, r)
 }
 

--- a/pkg/trait/lockunlock/info_router.pb.go
+++ b/pkg/trait/lockunlock/info_router.pb.go
@@ -33,7 +33,7 @@ func WithLockUnlockInfoClientFactory(f func(name string) (traits.LockUnlockInfoC
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLockUnlockInfoServer(server, r)
 }
 

--- a/pkg/trait/metadata/api_router.pb.go
+++ b/pkg/trait/metadata/api_router.pb.go
@@ -35,7 +35,7 @@ func WithMetadataApiClientFactory(f func(name string) (traits.MetadataApiClient,
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMetadataApiServer(server, r)
 }
 

--- a/pkg/trait/metadata/info_router.pb.go
+++ b/pkg/trait/metadata/info_router.pb.go
@@ -33,7 +33,7 @@ func WithMetadataInfoClientFactory(f func(name string) (traits.MetadataInfoClien
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMetadataInfoServer(server, r)
 }
 

--- a/pkg/trait/metadata/model_server.go
+++ b/pkg/trait/metadata/model_server.go
@@ -3,9 +3,10 @@ package metadata
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
-	"google.golang.org/grpc"
 )
 
 type ModelServer struct {
@@ -23,7 +24,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMetadataApiServer(server, s)
 }
 

--- a/pkg/trait/microphone/api_router.pb.go
+++ b/pkg/trait/microphone/api_router.pb.go
@@ -36,7 +36,7 @@ func WithMicrophoneApiClientFactory(f func(name string) (traits.MicrophoneApiCli
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMicrophoneApiServer(server, r)
 }
 

--- a/pkg/trait/microphone/info_router.pb.go
+++ b/pkg/trait/microphone/info_router.pb.go
@@ -34,7 +34,7 @@ func WithMicrophoneInfoClientFactory(f func(name string) (traits.MicrophoneInfoC
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMicrophoneInfoServer(server, r)
 }
 

--- a/pkg/trait/mode/api_router.pb.go
+++ b/pkg/trait/mode/api_router.pb.go
@@ -35,7 +35,7 @@ func WithModeApiClientFactory(f func(name string) (traits.ModeApiClient, error))
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterModeApiServer(server, r)
 }
 

--- a/pkg/trait/mode/info_router.pb.go
+++ b/pkg/trait/mode/info_router.pb.go
@@ -34,7 +34,7 @@ func WithModeInfoClientFactory(f func(name string) (traits.ModeInfoClient, error
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterModeInfoServer(server, r)
 }
 

--- a/pkg/trait/mode/model_server.go
+++ b/pkg/trait/mode/model_server.go
@@ -3,11 +3,12 @@ package mode
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model as a traits.ModeApiServer.
@@ -21,7 +22,7 @@ func NewModelServer(model *Model) *ModelServer {
 	return &ModelServer{model: model}
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterModeApiServer(server, m)
 }
 

--- a/pkg/trait/motionsensor/api_router.pb.go
+++ b/pkg/trait/motionsensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithMotionSensorApiClientFactory(f func(name string) (traits.MotionSensorAp
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMotionSensorApiServer(server, r)
 }
 

--- a/pkg/trait/motionsensor/sensorinfo_router.pb.go
+++ b/pkg/trait/motionsensor/sensorinfo_router.pb.go
@@ -34,7 +34,7 @@ func WithMotionSensorSensorInfoClientFactory(f func(name string) (traits.MotionS
 	})
 }
 
-func (r *SensorInfoRouter) Register(server *grpc.Server) {
+func (r *SensorInfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMotionSensorSensorInfoServer(server, r)
 }
 

--- a/pkg/trait/occupancysensor/api_router.pb.go
+++ b/pkg/trait/occupancysensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithOccupancySensorApiClientFactory(f func(name string) (traits.OccupancySe
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOccupancySensorApiServer(server, r)
 }
 

--- a/pkg/trait/occupancysensor/info_router.pb.go
+++ b/pkg/trait/occupancysensor/info_router.pb.go
@@ -34,7 +34,7 @@ func WithOccupancySensorInfoClientFactory(f func(name string) (traits.OccupancyS
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOccupancySensorInfoServer(server, r)
 }
 

--- a/pkg/trait/occupancysensor/model_server.go
+++ b/pkg/trait/occupancysensor/model_server.go
@@ -3,11 +3,13 @@ package occupancysensor
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type ModelServer struct {
@@ -25,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOccupancySensorApiServer(server, s)
 }
 

--- a/pkg/trait/onoff/api_router.pb.go
+++ b/pkg/trait/onoff/api_router.pb.go
@@ -35,7 +35,7 @@ func WithOnOffApiClientFactory(f func(name string) (traits.OnOffApiClient, error
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOnOffApiServer(server, r)
 }
 

--- a/pkg/trait/onoff/info_router.pb.go
+++ b/pkg/trait/onoff/info_router.pb.go
@@ -34,7 +34,7 @@ func WithOnOffInfoClientFactory(f func(name string) (traits.OnOffInfoClient, err
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOnOffInfoServer(server, r)
 }
 

--- a/pkg/trait/onoff/model_server.go
+++ b/pkg/trait/onoff/model_server.go
@@ -3,10 +3,11 @@ package onoff
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 type ModelServer struct {
@@ -22,7 +23,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOnOffApiServer(server, s)
 }
 

--- a/pkg/trait/openclose/api_router.pb.go
+++ b/pkg/trait/openclose/api_router.pb.go
@@ -35,7 +35,7 @@ func WithOpenCloseApiClientFactory(f func(name string) (traits.OpenCloseApiClien
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOpenCloseApiServer(server, r)
 }
 

--- a/pkg/trait/openclose/info_router.pb.go
+++ b/pkg/trait/openclose/info_router.pb.go
@@ -34,7 +34,7 @@ func WithOpenCloseInfoClientFactory(f func(name string) (traits.OpenCloseInfoCli
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOpenCloseInfoServer(server, r)
 }
 

--- a/pkg/trait/openclose/model_server.go
+++ b/pkg/trait/openclose/model_server.go
@@ -19,7 +19,7 @@ func NewModelServer(model *Model) *ModelServer {
 	return &ModelServer{model: model}
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOpenCloseApiServer(server, s)
 }
 

--- a/pkg/trait/parent/api_router.pb.go
+++ b/pkg/trait/parent/api_router.pb.go
@@ -35,7 +35,7 @@ func WithParentApiClientFactory(f func(name string) (traits.ParentApiClient, err
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterParentApiServer(server, r)
 }
 

--- a/pkg/trait/parent/info_router.pb.go
+++ b/pkg/trait/parent/info_router.pb.go
@@ -33,7 +33,7 @@ func WithParentInfoClientFactory(f func(name string) (traits.ParentInfoClient, e
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterParentInfoServer(server, r)
 }
 

--- a/pkg/trait/ptz/api_router.pb.go
+++ b/pkg/trait/ptz/api_router.pb.go
@@ -35,7 +35,7 @@ func WithPtzApiClientFactory(f func(name string) (traits.PtzApiClient, error)) r
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPtzApiServer(server, r)
 }
 

--- a/pkg/trait/ptz/info_router.pb.go
+++ b/pkg/trait/ptz/info_router.pb.go
@@ -34,7 +34,7 @@ func WithPtzInfoClientFactory(f func(name string) (traits.PtzInfoClient, error))
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPtzInfoServer(server, r)
 }
 

--- a/pkg/trait/publication/api_router.pb.go
+++ b/pkg/trait/publication/api_router.pb.go
@@ -35,7 +35,7 @@ func WithPublicationApiClientFactory(f func(name string) (traits.PublicationApiC
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPublicationApiServer(server, r)
 }
 

--- a/pkg/trait/publication/model_server.go
+++ b/pkg/trait/publication/model_server.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 var VersionMismatchErr = status.Error(codes.FailedPrecondition, "version mismatch: update version != server version")
@@ -29,7 +30,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPublicationApiServer(server, m)
 }
 

--- a/pkg/trait/speaker/api_router.pb.go
+++ b/pkg/trait/speaker/api_router.pb.go
@@ -36,7 +36,7 @@ func WithSpeakerApiClientFactory(f func(name string) (traits.SpeakerApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterSpeakerApiServer(server, r)
 }
 

--- a/pkg/trait/speaker/info_router.pb.go
+++ b/pkg/trait/speaker/info_router.pb.go
@@ -34,7 +34,7 @@ func WithSpeakerInfoClientFactory(f func(name string) (traits.SpeakerInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterSpeakerInfoServer(server, r)
 }
 

--- a/pkg/trait/speaker/memory.go
+++ b/pkg/trait/speaker/memory.go
@@ -3,13 +3,15 @@ package speaker
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-api/go/types"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 type MemoryDevice struct {
@@ -23,7 +25,7 @@ func NewMemoryDevice(initialState *types.AudioLevel) *MemoryDevice {
 	}
 }
 
-func (s *MemoryDevice) Register(server *grpc.Server) {
+func (s *MemoryDevice) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterSpeakerApiServer(server, s)
 }
 

--- a/pkg/trait/vending/api_router.pb.go
+++ b/pkg/trait/vending/api_router.pb.go
@@ -35,7 +35,7 @@ func WithVendingApiClientFactory(f func(name string) (traits.VendingApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterVendingApiServer(server, r)
 }
 

--- a/pkg/trait/vending/info_router.pb.go
+++ b/pkg/trait/vending/info_router.pb.go
@@ -33,7 +33,7 @@ func WithVendingInfoClientFactory(f func(name string) (traits.VendingInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterVendingInfoServer(server, r)
 }
 

--- a/pkg/trait/vending/model_server.go
+++ b/pkg/trait/vending/model_server.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model to implement traits.VendingApiServer.
@@ -27,7 +28,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterVendingApiServer(server, m)
 }
 


### PR DESCRIPTION
Use the minimal interface `grpc.ServiceRegistrar` instead of `*grpc.Server`.

We will be phasing out the generated routers for routing in sc-bos. However we need to keep them around for now, for back-compatibility reasons in the `node` package etc. We will need the ability to register on any ServiceRegistrar.

This is technically an API-breaking change for implementors of `server.GrpcApi`, however I'm not aware of any implementations outside this repo (and it's trivial to fix, just the signature needs changing).
