### PR TITLE
Facilitate dynamic proxying in sc-bos

### DIFF
--- a/cmd/protoc-gen-router/router.go.gotxt
+++ b/cmd/protoc-gen-router/router.go.gotxt
@@ -29,7 +29,7 @@ func With{{.ClientName.Exported}}Factory(f func(name string) ({{.ClientName.Qual
   })
 }
 
-func (r *{{.RouterName}}) Register(server *grpc.Server) {
+func (r *{{.RouterName}}) Register(server grpc.ServiceRegistrar) {
 	{{.RegisterService.Qualified}}(server, r)
 }
 

--- a/cmd/protoc-gen-wrapper/main.go
+++ b/cmd/protoc-gen-wrapper/main.go
@@ -92,6 +92,14 @@ func newServiceModel(g *protogen.GeneratedFile, service *protogen.Service, file 
 			GoName:       "ServerToClient",
 			GoImportPath: "github.com/smart-core-os/sc-golang/pkg/wrap",
 		}),
+		GRPCClientConnInterface: g.QualifiedGoIdent(protogen.GoIdent{
+			GoName:       "ClientConnInterface",
+			GoImportPath: "google.golang.org/grpc",
+		}),
+		GRPCServiceDesc: g.QualifiedGoIdent(protogen.GoIdent{
+			GoName:       "ServiceDesc",
+			GoImportPath: "google.golang.org/grpc",
+		}),
 	}
 
 	return model
@@ -116,7 +124,9 @@ type ServiceModel struct {
 	QualifiedClientConstructor string
 	QualifiedServiceDesc       string
 
-	WrapServerToClient string
+	WrapServerToClient      string
+	GRPCClientConnInterface string
+	GRPCServiceDesc         string
 }
 
 type Ident struct {

--- a/cmd/protoc-gen-wrapper/wrapper.go.gotxt
+++ b/cmd/protoc-gen-wrapper/wrapper.go.gotxt
@@ -6,30 +6,35 @@ package {{.PackageName}}
 {{/*Imports handled by the invoker code*/}}
 
 // Wrap{{.Underlying.Exported}}	adapts a {{.QualifiedServerName}}	and presents it as a {{.QualifiedClientName}}
-func Wrap{{.Underlying.Exported}}(server {{.QualifiedServerName}}) {{.QualifiedClientName}} {
+func Wrap{{.Underlying.Exported}}(server {{.QualifiedServerName}}) *{{.Wrapper.Exported}} {
 	conn := {{.WrapServerToClient}}({{.QualifiedServiceDesc}}, server)
 	client := {{.QualifiedClientConstructor}}(conn)
-	return &{{.Wrapper.Private}}{
+	return &{{.Wrapper.Exported}}{
 		{{.ClientName}}: client,
-		server: server,
+		server:          server,
+		conn:            conn,
+		desc:            {{.QualifiedServiceDesc}},
 	}
 }
 
-type {{.Wrapper.Private}} struct {
+type {{.Wrapper.Exported}} struct {
 	{{.QualifiedClientName}}
 
 	server {{.QualifiedServerName}}
+	conn   {{.GRPCClientConnInterface}}
+	desc   {{.GRPCServiceDesc}}
 }
 
-// compile time check that we implement the interface we need
-var _ {{.QualifiedClientName}} = (*{{.Wrapper.Private}})(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *{{$.Wrapper.Private}}) UnwrapServer() {{.QualifiedServerName}} {
+func (w *{{$.Wrapper.Exported}}) UnwrapServer() {{.QualifiedServerName}} {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *{{$.Wrapper.Private}}) Unwrap() any {
+func (w *{{$.Wrapper.Exported}}) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *{{$.Wrapper.Exported}}) UnwrapService() ({{.GRPCClientConnInterface}}, {{.GRPCServiceDesc}}) {
+  return w.conn, w.desc
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/smart-core-os/sc-api/go v1.0.0-beta.45
 	github.com/tanema/gween v0.0.0-20200427131925-c89ae23cc63c
 	go.uber.org/zap v1.17.0
+	golang.org/x/exp v0.0.0-20240822175202-778ce7bba035
 	google.golang.org/grpc v1.60.1
 	google.golang.org/protobuf v1.33.0
 )
@@ -18,7 +19,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	go.uber.org/atomic v1.8.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
-	golang.org/x/exp v0.0.0-20240822175202-778ce7bba035 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20240822175202-778ce7bba035 h1:VkSUcpKXdGwUpn/JsiWXwSNnIJVXRfMA4ThL5vwljWg=
 golang.org/x/exp v0.0.0-20240822175202-778ce7bba035/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
-golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=
-golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -135,7 +133,6 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20231002182017-d307bd883b97 h1:SeZZZx0cP0fqUyA+oRzP9k7cSwJlvDFiROO72uwD6i0=
-google.golang.org/genproto v0.0.0-20231002182017-d307bd883b97/go.mod h1:t1VqOqqvce95G3hIDCT5FeO3YUc6Q4Oe24L/+rNMxRk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 h1:6GQBEOdGkX6MMTLT9V+TjtIRZCw9VPD5Z+yHY9wMgS0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97/go.mod h1:v7nGkzlmW8P3n/bKmWBn2WpBjpOEx8Q6gMueudAmKfY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/pkg/resource/opt.go
+++ b/pkg/resource/opt.go
@@ -101,6 +101,18 @@ func WithWritablePaths(m proto.Message, paths ...string) Option {
 	return WithWritableFields(mask)
 }
 
+type IDInterceptor = func(oldID string) (newID string)
+
+// WithIDInterceptor will map IDs provided to Collection methods to another ID before reading or writing from the
+// collection.
+// Applicable only to Collection.
+// For example, this can be used to make a case-insensitive collection by mapping all IDs to lowercase.
+func WithIDInterceptor(interceptor IDInterceptor) Option {
+	return optionFunc(func(s *config) {
+		s.idInterceptor = interceptor
+	})
+}
+
 type config struct {
 	clock          Clock
 	equivalence    Comparer
@@ -108,6 +120,7 @@ type config struct {
 	initialValue   proto.Message
 	initialRecords map[string]proto.Message
 	writableFields *fieldmaskpb.FieldMask
+	idInterceptor  IDInterceptor
 }
 
 func computeConfig(opts ...Option) *config {

--- a/pkg/resource/opt_test.go
+++ b/pkg/resource/opt_test.go
@@ -2,14 +2,16 @@ package resource
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
 )
 
 func TestWithUpdatesOnly(t *testing.T) {
@@ -297,6 +299,19 @@ func TestWithBackpressure_False(t *testing.T) {
 		case <-time.After(100 * time.Millisecond):
 		}
 	})
+}
+
+func TestWithIDInterceptor(t *testing.T) {
+	c := NewCollection(WithIDInterceptor(strings.ToLower))
+	add(t, c, "A", &traits.OnOff{State: traits.OnOff_ON})
+	expect := &traits.OnOff{State: traits.OnOff_ON}
+	actual, ok := c.Get("a")
+	if !ok {
+		t.Error("expected to find item with id 'a'")
+	}
+	if diff := cmp.Diff(expect, actual, protocmp.Transform()); diff != "" {
+		t.Errorf("Get('a') returned wrong value (-want,+got)\n%v", diff)
+	}
 }
 
 // List CollectionChange but without the timestamp

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -3,12 +3,12 @@ package server
 import "google.golang.org/grpc"
 
 type GrpcApi interface {
-	Register(server *grpc.Server)
+	Register(server grpc.ServiceRegistrar)
 }
 
 type collection []GrpcApi
 
-func (c collection) Register(server *grpc.Server) {
+func (c collection) Register(server grpc.ServiceRegistrar) {
 	for _, api := range c {
 		api.Register(server)
 	}

--- a/pkg/trait/airqualitysensor/api_router.pb.go
+++ b/pkg/trait/airqualitysensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithAirQualitySensorApiClientFactory(f func(name string) (traits.AirQuality
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirQualitySensorApiServer(server, r)
 }
 

--- a/pkg/trait/airqualitysensor/info_router.pb.go
+++ b/pkg/trait/airqualitysensor/info_router.pb.go
@@ -34,7 +34,7 @@ func WithAirQualitySensorInfoClientFactory(f func(name string) (traits.AirQualit
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirQualitySensorInfoServer(server, r)
 }
 

--- a/pkg/trait/airqualitysensor/info_wrap.pb.go
+++ b/pkg/trait/airqualitysensor/info_wrap.pb.go
@@ -5,33 +5,39 @@ package airqualitysensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.AirQualitySensorInfoServer	and presents it as a traits.AirQualitySensorInfoClient
-func WrapInfo(server traits.AirQualitySensorInfoServer) traits.AirQualitySensorInfoClient {
+func WrapInfo(server traits.AirQualitySensorInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.AirQualitySensorInfo_ServiceDesc, server)
 	client := traits.NewAirQualitySensorInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		AirQualitySensorInfoClient: client,
 		server:                     server,
+		conn:                       conn,
+		desc:                       traits.AirQualitySensorInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.AirQualitySensorInfoClient
 
 	server traits.AirQualitySensorInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.AirQualitySensorInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.AirQualitySensorInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.AirQualitySensorInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/airqualitysensor/model_server.go
+++ b/pkg/trait/airqualitysensor/model_server.go
@@ -3,11 +3,13 @@ package airqualitysensor
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type ModelServer struct {
@@ -25,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirQualitySensorApiServer(server, s)
 }
 

--- a/pkg/trait/airtemperature/api_router.pb.go
+++ b/pkg/trait/airtemperature/api_router.pb.go
@@ -35,7 +35,7 @@ func WithAirTemperatureApiClientFactory(f func(name string) (traits.AirTemperatu
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureApiServer(server, r)
 }
 

--- a/pkg/trait/airtemperature/api_wrap.pb.go
+++ b/pkg/trait/airtemperature/api_wrap.pb.go
@@ -5,33 +5,39 @@ package airtemperature
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.AirTemperatureApiServer	and presents it as a traits.AirTemperatureApiClient
-func WrapApi(server traits.AirTemperatureApiServer) traits.AirTemperatureApiClient {
+func WrapApi(server traits.AirTemperatureApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.AirTemperatureApi_ServiceDesc, server)
 	client := traits.NewAirTemperatureApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		AirTemperatureApiClient: client,
 		server:                  server,
+		conn:                    conn,
+		desc:                    traits.AirTemperatureApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.AirTemperatureApiClient
 
 	server traits.AirTemperatureApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.AirTemperatureApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.AirTemperatureApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.AirTemperatureApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/airtemperature/info_router.pb.go
+++ b/pkg/trait/airtemperature/info_router.pb.go
@@ -34,7 +34,7 @@ func WithAirTemperatureInfoClientFactory(f func(name string) (traits.AirTemperat
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureInfoServer(server, r)
 }
 

--- a/pkg/trait/airtemperature/info_wrap.pb.go
+++ b/pkg/trait/airtemperature/info_wrap.pb.go
@@ -5,33 +5,39 @@ package airtemperature
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.AirTemperatureInfoServer	and presents it as a traits.AirTemperatureInfoClient
-func WrapInfo(server traits.AirTemperatureInfoServer) traits.AirTemperatureInfoClient {
+func WrapInfo(server traits.AirTemperatureInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.AirTemperatureInfo_ServiceDesc, server)
 	client := traits.NewAirTemperatureInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		AirTemperatureInfoClient: client,
 		server:                   server,
+		conn:                     conn,
+		desc:                     traits.AirTemperatureInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.AirTemperatureInfoClient
 
 	server traits.AirTemperatureInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.AirTemperatureInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.AirTemperatureInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.AirTemperatureInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/airtemperature/memory.go
+++ b/pkg/trait/airtemperature/memory.go
@@ -3,11 +3,12 @@ package airtemperature
 import (
 	"context"
 
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-api/go/types"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type MemoryDevice struct {
@@ -39,7 +40,7 @@ func InitialAirTemperatureState() *traits.AirTemperature {
 	}
 }
 
-func (t *MemoryDevice) Register(server *grpc.Server) {
+func (t *MemoryDevice) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureApiServer(server, t)
 }
 

--- a/pkg/trait/airtemperature/model_server.go
+++ b/pkg/trait/airtemperature/model_server.go
@@ -3,11 +3,13 @@ package airtemperature
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type ModelServer struct {
@@ -25,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterAirTemperatureApiServer(server, s)
 }
 

--- a/pkg/trait/booking/api_router.pb.go
+++ b/pkg/trait/booking/api_router.pb.go
@@ -35,7 +35,7 @@ func WithBookingApiClientFactory(f func(name string) (traits.BookingApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBookingApiServer(server, r)
 }
 

--- a/pkg/trait/booking/info_router.pb.go
+++ b/pkg/trait/booking/info_router.pb.go
@@ -34,7 +34,7 @@ func WithBookingInfoClientFactory(f func(name string) (traits.BookingInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBookingInfoServer(server, r)
 }
 

--- a/pkg/trait/booking/model_server.go
+++ b/pkg/trait/booking/model_server.go
@@ -3,14 +3,15 @@ package booking
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types/time"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
-	timepb "github.com/smart-core-os/sc-golang/pkg/time"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types/time"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+	timepb "github.com/smart-core-os/sc-golang/pkg/time"
 )
 
 type ModelServer struct {
@@ -27,7 +28,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBookingApiServer(server, m)
 }
 

--- a/pkg/trait/brightnesssensor/api_router.pb.go
+++ b/pkg/trait/brightnesssensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithBrightnessSensorApiClientFactory(f func(name string) (traits.Brightness
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBrightnessSensorApiServer(server, r)
 }
 

--- a/pkg/trait/brightnesssensor/api_wrap.pb.go
+++ b/pkg/trait/brightnesssensor/api_wrap.pb.go
@@ -5,33 +5,39 @@ package brightnesssensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.BrightnessSensorApiServer	and presents it as a traits.BrightnessSensorApiClient
-func WrapApi(server traits.BrightnessSensorApiServer) traits.BrightnessSensorApiClient {
+func WrapApi(server traits.BrightnessSensorApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.BrightnessSensorApi_ServiceDesc, server)
 	client := traits.NewBrightnessSensorApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		BrightnessSensorApiClient: client,
 		server:                    server,
+		conn:                      conn,
+		desc:                      traits.BrightnessSensorApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.BrightnessSensorApiClient
 
 	server traits.BrightnessSensorApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.BrightnessSensorApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.BrightnessSensorApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.BrightnessSensorApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/brightnesssensor/info_router.pb.go
+++ b/pkg/trait/brightnesssensor/info_router.pb.go
@@ -34,7 +34,7 @@ func WithBrightnessSensorInfoClientFactory(f func(name string) (traits.Brightnes
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterBrightnessSensorInfoServer(server, r)
 }
 

--- a/pkg/trait/brightnesssensor/info_wrap.pb.go
+++ b/pkg/trait/brightnesssensor/info_wrap.pb.go
@@ -5,33 +5,39 @@ package brightnesssensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.BrightnessSensorInfoServer	and presents it as a traits.BrightnessSensorInfoClient
-func WrapInfo(server traits.BrightnessSensorInfoServer) traits.BrightnessSensorInfoClient {
+func WrapInfo(server traits.BrightnessSensorInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.BrightnessSensorInfo_ServiceDesc, server)
 	client := traits.NewBrightnessSensorInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		BrightnessSensorInfoClient: client,
 		server:                     server,
+		conn:                       conn,
+		desc:                       traits.BrightnessSensorInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.BrightnessSensorInfoClient
 
 	server traits.BrightnessSensorInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.BrightnessSensorInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.BrightnessSensorInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.BrightnessSensorInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/channel/api_router.pb.go
+++ b/pkg/trait/channel/api_router.pb.go
@@ -35,7 +35,7 @@ func WithChannelApiClientFactory(f func(name string) (traits.ChannelApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterChannelApiServer(server, r)
 }
 

--- a/pkg/trait/channel/api_wrap.pb.go
+++ b/pkg/trait/channel/api_wrap.pb.go
@@ -5,33 +5,39 @@ package channel
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.ChannelApiServer	and presents it as a traits.ChannelApiClient
-func WrapApi(server traits.ChannelApiServer) traits.ChannelApiClient {
+func WrapApi(server traits.ChannelApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.ChannelApi_ServiceDesc, server)
 	client := traits.NewChannelApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		ChannelApiClient: client,
 		server:           server,
+		conn:             conn,
+		desc:             traits.ChannelApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.ChannelApiClient
 
 	server traits.ChannelApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ChannelApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.ChannelApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.ChannelApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/channel/info_router.pb.go
+++ b/pkg/trait/channel/info_router.pb.go
@@ -34,7 +34,7 @@ func WithChannelInfoClientFactory(f func(name string) (traits.ChannelInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterChannelInfoServer(server, r)
 }
 

--- a/pkg/trait/count/api_router.pb.go
+++ b/pkg/trait/count/api_router.pb.go
@@ -35,7 +35,7 @@ func WithCountApiClientFactory(f func(name string) (traits.CountApiClient, error
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterCountApiServer(server, r)
 }
 

--- a/pkg/trait/count/info_router.pb.go
+++ b/pkg/trait/count/info_router.pb.go
@@ -34,7 +34,7 @@ func WithCountInfoClientFactory(f func(name string) (traits.CountInfoClient, err
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterCountInfoServer(server, r)
 }
 

--- a/pkg/trait/count/info_wrap.pb.go
+++ b/pkg/trait/count/info_wrap.pb.go
@@ -5,33 +5,39 @@ package count
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.CountInfoServer	and presents it as a traits.CountInfoClient
-func WrapInfo(server traits.CountInfoServer) traits.CountInfoClient {
+func WrapInfo(server traits.CountInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.CountInfo_ServiceDesc, server)
 	client := traits.NewCountInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		CountInfoClient: client,
 		server:          server,
+		conn:            conn,
+		desc:            traits.CountInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.CountInfoClient
 
 	server traits.CountInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.CountInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.CountInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.CountInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/electric/api_router.pb.go
+++ b/pkg/trait/electric/api_router.pb.go
@@ -35,7 +35,7 @@ func WithElectricApiClientFactory(f func(name string) (traits.ElectricApiClient,
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterElectricApiServer(server, r)
 }
 

--- a/pkg/trait/electric/api_wrap.pb.go
+++ b/pkg/trait/electric/api_wrap.pb.go
@@ -5,33 +5,39 @@ package electric
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.ElectricApiServer	and presents it as a traits.ElectricApiClient
-func WrapApi(server traits.ElectricApiServer) traits.ElectricApiClient {
+func WrapApi(server traits.ElectricApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.ElectricApi_ServiceDesc, server)
 	client := traits.NewElectricApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		ElectricApiClient: client,
 		server:            server,
+		conn:              conn,
+		desc:              traits.ElectricApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.ElectricApiClient
 
 	server traits.ElectricApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ElectricApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.ElectricApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.ElectricApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/electric/info_router.pb.go
+++ b/pkg/trait/electric/info_router.pb.go
@@ -33,7 +33,7 @@ func WithElectricInfoClientFactory(f func(name string) (traits.ElectricInfoClien
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterElectricInfoServer(server, r)
 }
 

--- a/pkg/trait/electric/info_wrap.pb.go
+++ b/pkg/trait/electric/info_wrap.pb.go
@@ -5,33 +5,39 @@ package electric
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.ElectricInfoServer	and presents it as a traits.ElectricInfoClient
-func WrapInfo(server traits.ElectricInfoServer) traits.ElectricInfoClient {
+func WrapInfo(server traits.ElectricInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.ElectricInfo_ServiceDesc, server)
 	client := traits.NewElectricInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		ElectricInfoClient: client,
 		server:             server,
+		conn:               conn,
+		desc:               traits.ElectricInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.ElectricInfoClient
 
 	server traits.ElectricInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ElectricInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.ElectricInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.ElectricInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/electric/memorysettingsapi_router.pb.go
+++ b/pkg/trait/electric/memorysettingsapi_router.pb.go
@@ -35,7 +35,7 @@ func WithMemorySettingsApiClientFactory(f func(name string) (MemorySettingsApiCl
 	})
 }
 
-func (r *MemorySettingsApiRouter) Register(server *grpc.Server) {
+func (r *MemorySettingsApiRouter) Register(server grpc.ServiceRegistrar) {
 	RegisterMemorySettingsApiServer(server, r)
 }
 

--- a/pkg/trait/electric/memorysettingsapi_wrap.pb.go
+++ b/pkg/trait/electric/memorysettingsapi_wrap.pb.go
@@ -4,33 +4,39 @@ package electric
 
 import (
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapMemorySettingsApi	adapts a MemorySettingsApiServer	and presents it as a MemorySettingsApiClient
-func WrapMemorySettingsApi(server MemorySettingsApiServer) MemorySettingsApiClient {
+func WrapMemorySettingsApi(server MemorySettingsApiServer) *MemorySettingsApiWrapper {
 	conn := wrap.ServerToClient(MemorySettingsApi_ServiceDesc, server)
 	client := NewMemorySettingsApiClient(conn)
-	return &memorySettingsApiWrapper{
+	return &MemorySettingsApiWrapper{
 		MemorySettingsApiClient: client,
 		server:                  server,
+		conn:                    conn,
+		desc:                    MemorySettingsApi_ServiceDesc,
 	}
 }
 
-type memorySettingsApiWrapper struct {
+type MemorySettingsApiWrapper struct {
 	MemorySettingsApiClient
 
 	server MemorySettingsApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ MemorySettingsApiClient = (*memorySettingsApiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *memorySettingsApiWrapper) UnwrapServer() MemorySettingsApiServer {
+func (w *MemorySettingsApiWrapper) UnwrapServer() MemorySettingsApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *memorySettingsApiWrapper) Unwrap() any {
+func (w *MemorySettingsApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *MemorySettingsApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/electric/model_server.go
+++ b/pkg/trait/electric/model_server.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
 
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
@@ -32,7 +33,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterElectricApiServer(server, s)
 	RegisterMemorySettingsApiServer(server, s)
 }

--- a/pkg/trait/emergency/api_router.pb.go
+++ b/pkg/trait/emergency/api_router.pb.go
@@ -35,7 +35,7 @@ func WithEmergencyApiClientFactory(f func(name string) (traits.EmergencyApiClien
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEmergencyApiServer(server, r)
 }
 

--- a/pkg/trait/emergency/info_router.pb.go
+++ b/pkg/trait/emergency/info_router.pb.go
@@ -34,7 +34,7 @@ func WithEmergencyInfoClientFactory(f func(name string) (traits.EmergencyInfoCli
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEmergencyInfoServer(server, r)
 }
 

--- a/pkg/trait/emergency/info_wrap.pb.go
+++ b/pkg/trait/emergency/info_wrap.pb.go
@@ -5,33 +5,39 @@ package emergency
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.EmergencyInfoServer	and presents it as a traits.EmergencyInfoClient
-func WrapInfo(server traits.EmergencyInfoServer) traits.EmergencyInfoClient {
+func WrapInfo(server traits.EmergencyInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.EmergencyInfo_ServiceDesc, server)
 	client := traits.NewEmergencyInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		EmergencyInfoClient: client,
 		server:              server,
+		conn:                conn,
+		desc:                traits.EmergencyInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.EmergencyInfoClient
 
 	server traits.EmergencyInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.EmergencyInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.EmergencyInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.EmergencyInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/emergency/memory.go
+++ b/pkg/trait/emergency/memory.go
@@ -3,12 +3,14 @@ package emergency
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type MemoryDevice struct {
@@ -29,7 +31,7 @@ func InitialEmergency() *traits.Emergency {
 	}
 }
 
-func (t *MemoryDevice) Register(server *grpc.Server) {
+func (t *MemoryDevice) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEmergencyApiServer(server, t)
 }
 

--- a/pkg/trait/energystorage/api_router.pb.go
+++ b/pkg/trait/energystorage/api_router.pb.go
@@ -35,7 +35,7 @@ func WithEnergyStorageApiClientFactory(f func(name string) (traits.EnergyStorage
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnergyStorageApiServer(server, r)
 }
 

--- a/pkg/trait/energystorage/info_router.pb.go
+++ b/pkg/trait/energystorage/info_router.pb.go
@@ -34,7 +34,7 @@ func WithEnergyStorageInfoClientFactory(f func(name string) (traits.EnergyStorag
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnergyStorageInfoServer(server, r)
 }
 

--- a/pkg/trait/energystorage/info_wrap.pb.go
+++ b/pkg/trait/energystorage/info_wrap.pb.go
@@ -5,33 +5,39 @@ package energystorage
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.EnergyStorageInfoServer	and presents it as a traits.EnergyStorageInfoClient
-func WrapInfo(server traits.EnergyStorageInfoServer) traits.EnergyStorageInfoClient {
+func WrapInfo(server traits.EnergyStorageInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.EnergyStorageInfo_ServiceDesc, server)
 	client := traits.NewEnergyStorageInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		EnergyStorageInfoClient: client,
 		server:                  server,
+		conn:                    conn,
+		desc:                    traits.EnergyStorageInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.EnergyStorageInfoClient
 
 	server traits.EnergyStorageInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.EnergyStorageInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.EnergyStorageInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.EnergyStorageInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/energystorage/model_server.go
+++ b/pkg/trait/energystorage/model_server.go
@@ -3,12 +3,13 @@ package energystorage
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 type ModelServer struct {
@@ -31,7 +32,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnergyStorageApiServer(server, s)
 }
 

--- a/pkg/trait/enterleavesensor/api_router.pb.go
+++ b/pkg/trait/enterleavesensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithEnterLeaveSensorApiClientFactory(f func(name string) (traits.EnterLeave
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnterLeaveSensorApiServer(server, r)
 }
 

--- a/pkg/trait/enterleavesensor/api_wrap.pb.go
+++ b/pkg/trait/enterleavesensor/api_wrap.pb.go
@@ -5,33 +5,39 @@ package enterleavesensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.EnterLeaveSensorApiServer	and presents it as a traits.EnterLeaveSensorApiClient
-func WrapApi(server traits.EnterLeaveSensorApiServer) traits.EnterLeaveSensorApiClient {
+func WrapApi(server traits.EnterLeaveSensorApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.EnterLeaveSensorApi_ServiceDesc, server)
 	client := traits.NewEnterLeaveSensorApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		EnterLeaveSensorApiClient: client,
 		server:                    server,
+		conn:                      conn,
+		desc:                      traits.EnterLeaveSensorApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.EnterLeaveSensorApiClient
 
 	server traits.EnterLeaveSensorApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.EnterLeaveSensorApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.EnterLeaveSensorApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.EnterLeaveSensorApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/enterleavesensor/info_router.pb.go
+++ b/pkg/trait/enterleavesensor/info_router.pb.go
@@ -33,7 +33,7 @@ func WithEnterLeaveSensorInfoClientFactory(f func(name string) (traits.EnterLeav
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnterLeaveSensorInfoServer(server, r)
 }
 

--- a/pkg/trait/enterleavesensor/info_wrap.pb.go
+++ b/pkg/trait/enterleavesensor/info_wrap.pb.go
@@ -5,33 +5,39 @@ package enterleavesensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.EnterLeaveSensorInfoServer	and presents it as a traits.EnterLeaveSensorInfoClient
-func WrapInfo(server traits.EnterLeaveSensorInfoServer) traits.EnterLeaveSensorInfoClient {
+func WrapInfo(server traits.EnterLeaveSensorInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.EnterLeaveSensorInfo_ServiceDesc, server)
 	client := traits.NewEnterLeaveSensorInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		EnterLeaveSensorInfoClient: client,
 		server:                     server,
+		conn:                       conn,
+		desc:                       traits.EnterLeaveSensorInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.EnterLeaveSensorInfoClient
 
 	server traits.EnterLeaveSensorInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.EnterLeaveSensorInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.EnterLeaveSensorInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.EnterLeaveSensorInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/enterleavesensor/model_server.go
+++ b/pkg/trait/enterleavesensor/model_server.go
@@ -24,7 +24,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterEnterLeaveSensorApiServer(server, m)
 }
 

--- a/pkg/trait/extendretract/api_router.pb.go
+++ b/pkg/trait/extendretract/api_router.pb.go
@@ -35,7 +35,7 @@ func WithExtendRetractApiClientFactory(f func(name string) (traits.ExtendRetract
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterExtendRetractApiServer(server, r)
 }
 

--- a/pkg/trait/extendretract/api_wrap.pb.go
+++ b/pkg/trait/extendretract/api_wrap.pb.go
@@ -5,33 +5,39 @@ package extendretract
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.ExtendRetractApiServer	and presents it as a traits.ExtendRetractApiClient
-func WrapApi(server traits.ExtendRetractApiServer) traits.ExtendRetractApiClient {
+func WrapApi(server traits.ExtendRetractApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.ExtendRetractApi_ServiceDesc, server)
 	client := traits.NewExtendRetractApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		ExtendRetractApiClient: client,
 		server:                 server,
+		conn:                   conn,
+		desc:                   traits.ExtendRetractApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.ExtendRetractApiClient
 
 	server traits.ExtendRetractApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ExtendRetractApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.ExtendRetractApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.ExtendRetractApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/extendretract/info_router.pb.go
+++ b/pkg/trait/extendretract/info_router.pb.go
@@ -34,7 +34,7 @@ func WithExtendRetractInfoClientFactory(f func(name string) (traits.ExtendRetrac
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterExtendRetractInfoServer(server, r)
 }
 

--- a/pkg/trait/extendretract/info_wrap.pb.go
+++ b/pkg/trait/extendretract/info_wrap.pb.go
@@ -5,33 +5,39 @@ package extendretract
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.ExtendRetractInfoServer	and presents it as a traits.ExtendRetractInfoClient
-func WrapInfo(server traits.ExtendRetractInfoServer) traits.ExtendRetractInfoClient {
+func WrapInfo(server traits.ExtendRetractInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.ExtendRetractInfo_ServiceDesc, server)
 	client := traits.NewExtendRetractInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		ExtendRetractInfoClient: client,
 		server:                  server,
+		conn:                    conn,
+		desc:                    traits.ExtendRetractInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.ExtendRetractInfoClient
 
 	server traits.ExtendRetractInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ExtendRetractInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.ExtendRetractInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.ExtendRetractInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/fanspeed/api_router.pb.go
+++ b/pkg/trait/fanspeed/api_router.pb.go
@@ -35,7 +35,7 @@ func WithFanSpeedApiClientFactory(f func(name string) (traits.FanSpeedApiClient,
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterFanSpeedApiServer(server, r)
 }
 

--- a/pkg/trait/fanspeed/api_wrap.pb.go
+++ b/pkg/trait/fanspeed/api_wrap.pb.go
@@ -5,33 +5,39 @@ package fanspeed
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.FanSpeedApiServer	and presents it as a traits.FanSpeedApiClient
-func WrapApi(server traits.FanSpeedApiServer) traits.FanSpeedApiClient {
+func WrapApi(server traits.FanSpeedApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.FanSpeedApi_ServiceDesc, server)
 	client := traits.NewFanSpeedApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		FanSpeedApiClient: client,
 		server:            server,
+		conn:              conn,
+		desc:              traits.FanSpeedApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.FanSpeedApiClient
 
 	server traits.FanSpeedApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.FanSpeedApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.FanSpeedApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.FanSpeedApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/fanspeed/info_router.pb.go
+++ b/pkg/trait/fanspeed/info_router.pb.go
@@ -34,7 +34,7 @@ func WithFanSpeedInfoClientFactory(f func(name string) (traits.FanSpeedInfoClien
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterFanSpeedInfoServer(server, r)
 }
 

--- a/pkg/trait/fanspeed/info_wrap.pb.go
+++ b/pkg/trait/fanspeed/info_wrap.pb.go
@@ -5,33 +5,39 @@ package fanspeed
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.FanSpeedInfoServer	and presents it as a traits.FanSpeedInfoClient
-func WrapInfo(server traits.FanSpeedInfoServer) traits.FanSpeedInfoClient {
+func WrapInfo(server traits.FanSpeedInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.FanSpeedInfo_ServiceDesc, server)
 	client := traits.NewFanSpeedInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		FanSpeedInfoClient: client,
 		server:             server,
+		conn:               conn,
+		desc:               traits.FanSpeedInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.FanSpeedInfoClient
 
 	server traits.FanSpeedInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.FanSpeedInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.FanSpeedInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.FanSpeedInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/fanspeed/model_server.go
+++ b/pkg/trait/fanspeed/model_server.go
@@ -3,11 +3,12 @@ package fanspeed
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model as a traits.FanSpeedApiServer.
@@ -24,7 +25,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterFanSpeedApiServer(server, s)
 }
 

--- a/pkg/trait/hail/api_router.pb.go
+++ b/pkg/trait/hail/api_router.pb.go
@@ -35,7 +35,7 @@ func WithHailApiClientFactory(f func(name string) (traits.HailApiClient, error))
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterHailApiServer(server, r)
 }
 

--- a/pkg/trait/hail/info_router.pb.go
+++ b/pkg/trait/hail/info_router.pb.go
@@ -33,7 +33,7 @@ func WithHailInfoClientFactory(f func(name string) (traits.HailInfoClient, error
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterHailInfoServer(server, r)
 }
 

--- a/pkg/trait/hail/model_server.go
+++ b/pkg/trait/hail/model_server.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model to implement traits.HailApiServer.
@@ -27,7 +28,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterHailApiServer(server, m)
 }
 

--- a/pkg/trait/inputselect/api_router.pb.go
+++ b/pkg/trait/inputselect/api_router.pb.go
@@ -35,7 +35,7 @@ func WithInputSelectApiClientFactory(f func(name string) (traits.InputSelectApiC
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterInputSelectApiServer(server, r)
 }
 

--- a/pkg/trait/inputselect/api_wrap.pb.go
+++ b/pkg/trait/inputselect/api_wrap.pb.go
@@ -5,33 +5,39 @@ package inputselect
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.InputSelectApiServer	and presents it as a traits.InputSelectApiClient
-func WrapApi(server traits.InputSelectApiServer) traits.InputSelectApiClient {
+func WrapApi(server traits.InputSelectApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.InputSelectApi_ServiceDesc, server)
 	client := traits.NewInputSelectApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		InputSelectApiClient: client,
 		server:               server,
+		conn:                 conn,
+		desc:                 traits.InputSelectApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.InputSelectApiClient
 
 	server traits.InputSelectApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.InputSelectApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.InputSelectApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.InputSelectApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/inputselect/info_router.pb.go
+++ b/pkg/trait/inputselect/info_router.pb.go
@@ -34,7 +34,7 @@ func WithInputSelectInfoClientFactory(f func(name string) (traits.InputSelectInf
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterInputSelectInfoServer(server, r)
 }
 

--- a/pkg/trait/inputselect/info_wrap.pb.go
+++ b/pkg/trait/inputselect/info_wrap.pb.go
@@ -5,33 +5,39 @@ package inputselect
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.InputSelectInfoServer	and presents it as a traits.InputSelectInfoClient
-func WrapInfo(server traits.InputSelectInfoServer) traits.InputSelectInfoClient {
+func WrapInfo(server traits.InputSelectInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.InputSelectInfo_ServiceDesc, server)
 	client := traits.NewInputSelectInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		InputSelectInfoClient: client,
 		server:                server,
+		conn:                  conn,
+		desc:                  traits.InputSelectInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.InputSelectInfoClient
 
 	server traits.InputSelectInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.InputSelectInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.InputSelectInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.InputSelectInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/light/api_router.pb.go
+++ b/pkg/trait/light/api_router.pb.go
@@ -35,7 +35,7 @@ func WithLightApiClientFactory(f func(name string) (traits.LightApiClient, error
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLightApiServer(server, r)
 }
 

--- a/pkg/trait/light/api_wrap.pb.go
+++ b/pkg/trait/light/api_wrap.pb.go
@@ -5,33 +5,39 @@ package light
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.LightApiServer	and presents it as a traits.LightApiClient
-func WrapApi(server traits.LightApiServer) traits.LightApiClient {
+func WrapApi(server traits.LightApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.LightApi_ServiceDesc, server)
 	client := traits.NewLightApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		LightApiClient: client,
 		server:         server,
+		conn:           conn,
+		desc:           traits.LightApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.LightApiClient
 
 	server traits.LightApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.LightApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.LightApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.LightApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/light/info_router.pb.go
+++ b/pkg/trait/light/info_router.pb.go
@@ -34,7 +34,7 @@ func WithLightInfoClientFactory(f func(name string) (traits.LightInfoClient, err
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLightInfoServer(server, r)
 }
 

--- a/pkg/trait/light/info_wrap.pb.go
+++ b/pkg/trait/light/info_wrap.pb.go
@@ -5,33 +5,39 @@ package light
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.LightInfoServer	and presents it as a traits.LightInfoClient
-func WrapInfo(server traits.LightInfoServer) traits.LightInfoClient {
+func WrapInfo(server traits.LightInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.LightInfo_ServiceDesc, server)
 	client := traits.NewLightInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		LightInfoClient: client,
 		server:          server,
+		conn:            conn,
+		desc:            traits.LightInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.LightInfoClient
 
 	server traits.LightInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.LightInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.LightInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.LightInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/light/model_server.go
+++ b/pkg/trait/light/model_server.go
@@ -27,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLightApiServer(server, s)
 	traits.RegisterLightInfoServer(server, s)
 }

--- a/pkg/trait/lockunlock/api_router.pb.go
+++ b/pkg/trait/lockunlock/api_router.pb.go
@@ -35,7 +35,7 @@ func WithLockUnlockApiClientFactory(f func(name string) (traits.LockUnlockApiCli
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLockUnlockApiServer(server, r)
 }
 

--- a/pkg/trait/lockunlock/api_wrap.pb.go
+++ b/pkg/trait/lockunlock/api_wrap.pb.go
@@ -5,33 +5,39 @@ package lockunlock
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.LockUnlockApiServer	and presents it as a traits.LockUnlockApiClient
-func WrapApi(server traits.LockUnlockApiServer) traits.LockUnlockApiClient {
+func WrapApi(server traits.LockUnlockApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.LockUnlockApi_ServiceDesc, server)
 	client := traits.NewLockUnlockApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		LockUnlockApiClient: client,
 		server:              server,
+		conn:                conn,
+		desc:                traits.LockUnlockApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.LockUnlockApiClient
 
 	server traits.LockUnlockApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.LockUnlockApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.LockUnlockApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.LockUnlockApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/lockunlock/info_router.pb.go
+++ b/pkg/trait/lockunlock/info_router.pb.go
@@ -33,7 +33,7 @@ func WithLockUnlockInfoClientFactory(f func(name string) (traits.LockUnlockInfoC
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterLockUnlockInfoServer(server, r)
 }
 

--- a/pkg/trait/lockunlock/info_wrap.pb.go
+++ b/pkg/trait/lockunlock/info_wrap.pb.go
@@ -5,33 +5,39 @@ package lockunlock
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.LockUnlockInfoServer	and presents it as a traits.LockUnlockInfoClient
-func WrapInfo(server traits.LockUnlockInfoServer) traits.LockUnlockInfoClient {
+func WrapInfo(server traits.LockUnlockInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.LockUnlockInfo_ServiceDesc, server)
 	client := traits.NewLockUnlockInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		LockUnlockInfoClient: client,
 		server:               server,
+		conn:                 conn,
+		desc:                 traits.LockUnlockInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.LockUnlockInfoClient
 
 	server traits.LockUnlockInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.LockUnlockInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.LockUnlockInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.LockUnlockInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/metadata/api_router.pb.go
+++ b/pkg/trait/metadata/api_router.pb.go
@@ -35,7 +35,7 @@ func WithMetadataApiClientFactory(f func(name string) (traits.MetadataApiClient,
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMetadataApiServer(server, r)
 }
 

--- a/pkg/trait/metadata/collection.go
+++ b/pkg/trait/metadata/collection.go
@@ -49,7 +49,8 @@ func (m *Collection) DeleteMetadata(name string, opts ...resource.WriteOption) (
 }
 
 // MergeMetadata writes any present fields in metadata to the existing data.
-// Traits that exist in the given metadata are merged with existing traits using
+// Traits that exist in the given metadata are merged with existing traits, so that each trait appears only once and
+// the 'more' maps are merged.
 func (m *Collection) MergeMetadata(name string, metadata *traits.Metadata, opts ...resource.WriteOption) (*traits.Metadata, error) {
 	newOpts := make([]resource.WriteOption, 1, len(opts)+1)
 	newOpts[0] = resource.InterceptBefore(metadataMergeInterceptor)

--- a/pkg/trait/metadata/collection.go
+++ b/pkg/trait/metadata/collection.go
@@ -1,0 +1,135 @@
+package metadata
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+)
+
+type Collection struct {
+	metadata *resource.Collection
+}
+
+func NewCollection(opts ...resource.Option) *Collection {
+	collection := resource.NewCollection(opts...)
+	return &Collection{
+		metadata: collection,
+	}
+}
+
+func (m *Collection) GetMetadata(name string, opts ...resource.ReadOption) (*traits.Metadata, error) {
+	res, ok := m.metadata.Get(name, opts...)
+	if !ok {
+		return nil, status.Error(codes.NotFound, "metadata not found")
+	}
+	return res.(*traits.Metadata), nil
+}
+
+func (m *Collection) UpdateMetadata(name string, metadata *traits.Metadata, opts ...resource.WriteOption) (*traits.Metadata, error) {
+	res, err := m.metadata.Update(name, metadata, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*traits.Metadata), nil
+}
+
+func (m *Collection) DeleteMetadata(name string, opts ...resource.WriteOption) (*traits.Metadata, error) {
+	old, err := m.metadata.Delete(name, opts...)
+	var oldMetadata *traits.Metadata
+	if old != nil {
+		oldMetadata = old.(*traits.Metadata)
+	}
+	return oldMetadata, err
+}
+
+// MergeMetadata writes any present fields in metadata to the existing data.
+// Traits that exist in the given metadata are merged with existing traits using
+func (m *Collection) MergeMetadata(name string, metadata *traits.Metadata, opts ...resource.WriteOption) (*traits.Metadata, error) {
+	newOpts := make([]resource.WriteOption, 1, len(opts)+1)
+	newOpts[0] = resource.InterceptBefore(metadataMergeInterceptor)
+	newOpts = append(newOpts, opts...)
+	return m.UpdateMetadata(name, metadata, newOpts...)
+}
+
+func (m *Collection) UpdateTraitMetadata(name string, traitMetadata *traits.TraitMetadata, opts ...resource.WriteOption) (*traits.Metadata, error) {
+	return m.MergeMetadata(name, &traits.Metadata{Traits: []*traits.TraitMetadata{traitMetadata}}, opts...)
+}
+
+func (m *Collection) PullMetadata(ctx context.Context, name string, opts ...resource.ReadOption) <-chan *traits.PullMetadataResponse_Change {
+	send := make(chan *traits.PullMetadataResponse_Change)
+
+	// when ctx is cancelled, then the resource will close recv for us
+	recv := m.metadata.PullID(ctx, name, opts...)
+	go func() {
+		defer close(send)
+		for change := range recv {
+			protoChange := metadataValueChangeToProto(change)
+			protoChange.Name = name
+
+			select {
+			case <-ctx.Done():
+				return
+			case send <- protoChange:
+			}
+		}
+	}()
+
+	return send
+}
+
+func (m *Collection) PullAllMetadata(ctx context.Context, opts ...resource.ReadOption) <-chan CollectionChange {
+	send := make(chan CollectionChange)
+
+	recv := m.metadata.Pull(ctx, opts...)
+	go func() {
+		defer close(send)
+		for change := range recv {
+			select {
+			case <-ctx.Done():
+				return
+			case send <- collectionChangeFromResource(change):
+			}
+		}
+	}()
+	return send
+}
+
+func (m *Collection) ListMetadata(opts ...resource.ReadOption) []*traits.Metadata {
+	protoMsgs := m.metadata.List(opts...)
+	metadata := make([]*traits.Metadata, len(protoMsgs))
+	for i, protoMsg := range protoMsgs {
+		metadata[i] = protoMsg.(*traits.Metadata)
+	}
+	return metadata
+}
+
+type CollectionChange struct {
+	Name          string
+	ChangeTime    time.Time
+	ChangeType    types.ChangeType
+	OldValue      *traits.Metadata
+	NewValue      *traits.Metadata
+	LastSeedValue bool
+}
+
+func collectionChangeFromResource(change *resource.CollectionChange) CollectionChange {
+	result := CollectionChange{
+		Name:          change.Id,
+		ChangeTime:    change.ChangeTime,
+		ChangeType:    change.ChangeType,
+		LastSeedValue: change.LastSeedValue,
+	}
+	if oldV, ok := change.OldValue.(*traits.Metadata); ok {
+		result.OldValue = oldV
+	}
+	if newV, ok := change.NewValue.(*traits.Metadata); ok {
+		result.NewValue = newV
+	}
+	return result
+}

--- a/pkg/trait/metadata/collection_server.go
+++ b/pkg/trait/metadata/collection_server.go
@@ -1,0 +1,38 @@
+package metadata
+
+import (
+	"context"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+)
+
+type CollectionServer struct {
+	traits.UnimplementedMetadataApiServer
+	model *Collection
+}
+
+func NewCollectionServer(model *Collection) *CollectionServer {
+	s := &CollectionServer{model: model}
+	return s
+}
+
+func (s *CollectionServer) Unwrap() any {
+	return s.model
+}
+
+func (s *CollectionServer) GetMetadata(_ context.Context, request *traits.GetMetadataRequest) (*traits.Metadata, error) {
+	return s.model.GetMetadata(request.Name)
+}
+
+func (s *CollectionServer) PullMetadata(request *traits.PullMetadataRequest, server traits.MetadataApi_PullMetadataServer) error {
+	for change := range s.model.PullMetadata(server.Context(), request.Name, resource.WithReadMask(request.ReadMask), resource.WithUpdatesOnly(request.UpdatesOnly)) {
+		err := server.Send(&traits.PullMetadataResponse{Changes: []*traits.PullMetadataResponse_Change{
+			{Name: request.Name, ChangeTime: change.ChangeTime, Metadata: change.Metadata},
+		}})
+		if err != nil {
+			return err
+		}
+	}
+	return server.Context().Err() // the loop only ends when the context is done
+}

--- a/pkg/trait/metadata/info_router.pb.go
+++ b/pkg/trait/metadata/info_router.pb.go
@@ -33,7 +33,7 @@ func WithMetadataInfoClientFactory(f func(name string) (traits.MetadataInfoClien
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMetadataInfoServer(server, r)
 }
 

--- a/pkg/trait/metadata/model.go
+++ b/pkg/trait/metadata/model.go
@@ -36,7 +36,8 @@ func (m *Model) UpdateMetadata(metadata *traits.Metadata, opts ...resource.Write
 }
 
 // MergeMetadata writes any present fields in metadata to the existing data.
-// Traits that exist in the given metadata are merged with existing traits using
+// Traits that exist in the given metadata are merged with existing traits, so that each trait appears only once and
+// the 'more' maps are merged.
 func (m *Model) MergeMetadata(metadata *traits.Metadata, opts ...resource.WriteOption) (*traits.Metadata, error) {
 	newOpts := make([]resource.WriteOption, 1, len(opts)+1)
 	newOpts[0] = resource.InterceptBefore(metadataMergeInterceptor)

--- a/pkg/trait/metadata/model.go
+++ b/pkg/trait/metadata/model.go
@@ -78,7 +78,7 @@ func (m *Model) PullMetadata(ctx context.Context, opts ...resource.ReadOption) <
 			select {
 			case <-ctx.Done():
 				return
-			case send <- metadataChangeToProto(change):
+			case send <- metadataValueChangeToProto(change):
 			}
 		}
 	}()
@@ -86,7 +86,7 @@ func (m *Model) PullMetadata(ctx context.Context, opts ...resource.ReadOption) <
 	return send
 }
 
-func metadataChangeToProto(change *resource.ValueChange) *traits.PullMetadataResponse_Change {
+func metadataValueChangeToProto(change *resource.ValueChange) *traits.PullMetadataResponse_Change {
 	return &traits.PullMetadataResponse_Change{
 		ChangeTime: timestamppb.New(change.ChangeTime),
 		Metadata:   change.Value.(*traits.Metadata),

--- a/pkg/trait/metadata/model_server.go
+++ b/pkg/trait/metadata/model_server.go
@@ -3,9 +3,10 @@ package metadata
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
-	"google.golang.org/grpc"
 )
 
 type ModelServer struct {
@@ -23,7 +24,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMetadataApiServer(server, s)
 }
 

--- a/pkg/trait/microphone/api_router.pb.go
+++ b/pkg/trait/microphone/api_router.pb.go
@@ -36,7 +36,7 @@ func WithMicrophoneApiClientFactory(f func(name string) (traits.MicrophoneApiCli
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMicrophoneApiServer(server, r)
 }
 

--- a/pkg/trait/microphone/info_router.pb.go
+++ b/pkg/trait/microphone/info_router.pb.go
@@ -34,7 +34,7 @@ func WithMicrophoneInfoClientFactory(f func(name string) (traits.MicrophoneInfoC
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMicrophoneInfoServer(server, r)
 }
 

--- a/pkg/trait/mode/api_router.pb.go
+++ b/pkg/trait/mode/api_router.pb.go
@@ -35,7 +35,7 @@ func WithModeApiClientFactory(f func(name string) (traits.ModeApiClient, error))
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterModeApiServer(server, r)
 }
 

--- a/pkg/trait/mode/api_wrap.pb.go
+++ b/pkg/trait/mode/api_wrap.pb.go
@@ -5,33 +5,39 @@ package mode
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.ModeApiServer	and presents it as a traits.ModeApiClient
-func WrapApi(server traits.ModeApiServer) traits.ModeApiClient {
+func WrapApi(server traits.ModeApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.ModeApi_ServiceDesc, server)
 	client := traits.NewModeApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		ModeApiClient: client,
 		server:        server,
+		conn:          conn,
+		desc:          traits.ModeApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.ModeApiClient
 
 	server traits.ModeApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ModeApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.ModeApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.ModeApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/mode/info_router.pb.go
+++ b/pkg/trait/mode/info_router.pb.go
@@ -34,7 +34,7 @@ func WithModeInfoClientFactory(f func(name string) (traits.ModeInfoClient, error
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterModeInfoServer(server, r)
 }
 

--- a/pkg/trait/mode/model_server.go
+++ b/pkg/trait/mode/model_server.go
@@ -3,11 +3,12 @@ package mode
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model as a traits.ModeApiServer.
@@ -21,7 +22,7 @@ func NewModelServer(model *Model) *ModelServer {
 	return &ModelServer{model: model}
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterModeApiServer(server, m)
 }
 

--- a/pkg/trait/motionsensor/api_router.pb.go
+++ b/pkg/trait/motionsensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithMotionSensorApiClientFactory(f func(name string) (traits.MotionSensorAp
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMotionSensorApiServer(server, r)
 }
 

--- a/pkg/trait/motionsensor/api_wrap.pb.go
+++ b/pkg/trait/motionsensor/api_wrap.pb.go
@@ -5,33 +5,39 @@ package motionsensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.MotionSensorApiServer	and presents it as a traits.MotionSensorApiClient
-func WrapApi(server traits.MotionSensorApiServer) traits.MotionSensorApiClient {
+func WrapApi(server traits.MotionSensorApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.MotionSensorApi_ServiceDesc, server)
 	client := traits.NewMotionSensorApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		MotionSensorApiClient: client,
 		server:                server,
+		conn:                  conn,
+		desc:                  traits.MotionSensorApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.MotionSensorApiClient
 
 	server traits.MotionSensorApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.MotionSensorApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.MotionSensorApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.MotionSensorApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/motionsensor/sensorinfo_router.pb.go
+++ b/pkg/trait/motionsensor/sensorinfo_router.pb.go
@@ -34,7 +34,7 @@ func WithMotionSensorSensorInfoClientFactory(f func(name string) (traits.MotionS
 	})
 }
 
-func (r *SensorInfoRouter) Register(server *grpc.Server) {
+func (r *SensorInfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterMotionSensorSensorInfoServer(server, r)
 }
 

--- a/pkg/trait/motionsensor/sensorinfo_wrap.pb.go
+++ b/pkg/trait/motionsensor/sensorinfo_wrap.pb.go
@@ -5,33 +5,39 @@ package motionsensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapSensorInfo	adapts a traits.MotionSensorSensorInfoServer	and presents it as a traits.MotionSensorSensorInfoClient
-func WrapSensorInfo(server traits.MotionSensorSensorInfoServer) traits.MotionSensorSensorInfoClient {
+func WrapSensorInfo(server traits.MotionSensorSensorInfoServer) *SensorInfoWrapper {
 	conn := wrap.ServerToClient(traits.MotionSensorSensorInfo_ServiceDesc, server)
 	client := traits.NewMotionSensorSensorInfoClient(conn)
-	return &sensorInfoWrapper{
+	return &SensorInfoWrapper{
 		MotionSensorSensorInfoClient: client,
 		server:                       server,
+		conn:                         conn,
+		desc:                         traits.MotionSensorSensorInfo_ServiceDesc,
 	}
 }
 
-type sensorInfoWrapper struct {
+type SensorInfoWrapper struct {
 	traits.MotionSensorSensorInfoClient
 
 	server traits.MotionSensorSensorInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.MotionSensorSensorInfoClient = (*sensorInfoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *sensorInfoWrapper) UnwrapServer() traits.MotionSensorSensorInfoServer {
+func (w *SensorInfoWrapper) UnwrapServer() traits.MotionSensorSensorInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *sensorInfoWrapper) Unwrap() any {
+func (w *SensorInfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *SensorInfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/occupancysensor/api_router.pb.go
+++ b/pkg/trait/occupancysensor/api_router.pb.go
@@ -35,7 +35,7 @@ func WithOccupancySensorApiClientFactory(f func(name string) (traits.OccupancySe
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOccupancySensorApiServer(server, r)
 }
 

--- a/pkg/trait/occupancysensor/api_wrap.pb.go
+++ b/pkg/trait/occupancysensor/api_wrap.pb.go
@@ -5,33 +5,39 @@ package occupancysensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.OccupancySensorApiServer	and presents it as a traits.OccupancySensorApiClient
-func WrapApi(server traits.OccupancySensorApiServer) traits.OccupancySensorApiClient {
+func WrapApi(server traits.OccupancySensorApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.OccupancySensorApi_ServiceDesc, server)
 	client := traits.NewOccupancySensorApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		OccupancySensorApiClient: client,
 		server:                   server,
+		conn:                     conn,
+		desc:                     traits.OccupancySensorApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.OccupancySensorApiClient
 
 	server traits.OccupancySensorApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.OccupancySensorApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.OccupancySensorApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.OccupancySensorApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/occupancysensor/info_router.pb.go
+++ b/pkg/trait/occupancysensor/info_router.pb.go
@@ -34,7 +34,7 @@ func WithOccupancySensorInfoClientFactory(f func(name string) (traits.OccupancyS
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOccupancySensorInfoServer(server, r)
 }
 

--- a/pkg/trait/occupancysensor/info_wrap.pb.go
+++ b/pkg/trait/occupancysensor/info_wrap.pb.go
@@ -5,33 +5,39 @@ package occupancysensor
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.OccupancySensorInfoServer	and presents it as a traits.OccupancySensorInfoClient
-func WrapInfo(server traits.OccupancySensorInfoServer) traits.OccupancySensorInfoClient {
+func WrapInfo(server traits.OccupancySensorInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.OccupancySensorInfo_ServiceDesc, server)
 	client := traits.NewOccupancySensorInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		OccupancySensorInfoClient: client,
 		server:                    server,
+		conn:                      conn,
+		desc:                      traits.OccupancySensorInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.OccupancySensorInfoClient
 
 	server traits.OccupancySensorInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.OccupancySensorInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.OccupancySensorInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.OccupancySensorInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/occupancysensor/model_server.go
+++ b/pkg/trait/occupancysensor/model_server.go
@@ -3,11 +3,13 @@ package occupancysensor
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
 	"google.golang.org/grpc"
+
+	"github.com/smart-core-os/sc-api/go/traits"
 )
 
 type ModelServer struct {
@@ -25,7 +27,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOccupancySensorApiServer(server, s)
 }
 

--- a/pkg/trait/onoff/api_router.pb.go
+++ b/pkg/trait/onoff/api_router.pb.go
@@ -35,7 +35,7 @@ func WithOnOffApiClientFactory(f func(name string) (traits.OnOffApiClient, error
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOnOffApiServer(server, r)
 }
 

--- a/pkg/trait/onoff/api_wrap.pb.go
+++ b/pkg/trait/onoff/api_wrap.pb.go
@@ -5,33 +5,39 @@ package onoff
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.OnOffApiServer	and presents it as a traits.OnOffApiClient
-func WrapApi(server traits.OnOffApiServer) traits.OnOffApiClient {
+func WrapApi(server traits.OnOffApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.OnOffApi_ServiceDesc, server)
 	client := traits.NewOnOffApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		OnOffApiClient: client,
 		server:         server,
+		conn:           conn,
+		desc:           traits.OnOffApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.OnOffApiClient
 
 	server traits.OnOffApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.OnOffApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.OnOffApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.OnOffApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/onoff/info_router.pb.go
+++ b/pkg/trait/onoff/info_router.pb.go
@@ -34,7 +34,7 @@ func WithOnOffInfoClientFactory(f func(name string) (traits.OnOffInfoClient, err
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOnOffInfoServer(server, r)
 }
 

--- a/pkg/trait/onoff/info_wrap.pb.go
+++ b/pkg/trait/onoff/info_wrap.pb.go
@@ -5,33 +5,39 @@ package onoff
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.OnOffInfoServer	and presents it as a traits.OnOffInfoClient
-func WrapInfo(server traits.OnOffInfoServer) traits.OnOffInfoClient {
+func WrapInfo(server traits.OnOffInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.OnOffInfo_ServiceDesc, server)
 	client := traits.NewOnOffInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		OnOffInfoClient: client,
 		server:          server,
+		conn:            conn,
+		desc:            traits.OnOffInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.OnOffInfoClient
 
 	server traits.OnOffInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.OnOffInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.OnOffInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.OnOffInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/onoff/model_server.go
+++ b/pkg/trait/onoff/model_server.go
@@ -3,10 +3,11 @@ package onoff
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 type ModelServer struct {
@@ -22,7 +23,7 @@ func (s *ModelServer) Unwrap() any {
 	return s.model
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOnOffApiServer(server, s)
 }
 

--- a/pkg/trait/openclose/api_router.pb.go
+++ b/pkg/trait/openclose/api_router.pb.go
@@ -35,7 +35,7 @@ func WithOpenCloseApiClientFactory(f func(name string) (traits.OpenCloseApiClien
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOpenCloseApiServer(server, r)
 }
 

--- a/pkg/trait/openclose/api_wrap.pb.go
+++ b/pkg/trait/openclose/api_wrap.pb.go
@@ -5,33 +5,39 @@ package openclose
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.OpenCloseApiServer	and presents it as a traits.OpenCloseApiClient
-func WrapApi(server traits.OpenCloseApiServer) traits.OpenCloseApiClient {
+func WrapApi(server traits.OpenCloseApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.OpenCloseApi_ServiceDesc, server)
 	client := traits.NewOpenCloseApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		OpenCloseApiClient: client,
 		server:             server,
+		conn:               conn,
+		desc:               traits.OpenCloseApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.OpenCloseApiClient
 
 	server traits.OpenCloseApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.OpenCloseApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.OpenCloseApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.OpenCloseApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/openclose/info_router.pb.go
+++ b/pkg/trait/openclose/info_router.pb.go
@@ -34,7 +34,7 @@ func WithOpenCloseInfoClientFactory(f func(name string) (traits.OpenCloseInfoCli
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOpenCloseInfoServer(server, r)
 }
 

--- a/pkg/trait/openclose/model_server.go
+++ b/pkg/trait/openclose/model_server.go
@@ -19,7 +19,7 @@ func NewModelServer(model *Model) *ModelServer {
 	return &ModelServer{model: model}
 }
 
-func (s *ModelServer) Register(server *grpc.Server) {
+func (s *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterOpenCloseApiServer(server, s)
 }
 

--- a/pkg/trait/parent/api_router.pb.go
+++ b/pkg/trait/parent/api_router.pb.go
@@ -35,7 +35,7 @@ func WithParentApiClientFactory(f func(name string) (traits.ParentApiClient, err
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterParentApiServer(server, r)
 }
 

--- a/pkg/trait/parent/api_wrap.pb.go
+++ b/pkg/trait/parent/api_wrap.pb.go
@@ -5,33 +5,39 @@ package parent
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.ParentApiServer	and presents it as a traits.ParentApiClient
-func WrapApi(server traits.ParentApiServer) traits.ParentApiClient {
+func WrapApi(server traits.ParentApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.ParentApi_ServiceDesc, server)
 	client := traits.NewParentApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		ParentApiClient: client,
 		server:          server,
+		conn:            conn,
+		desc:            traits.ParentApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.ParentApiClient
 
 	server traits.ParentApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.ParentApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.ParentApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.ParentApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/parent/info_router.pb.go
+++ b/pkg/trait/parent/info_router.pb.go
@@ -33,7 +33,7 @@ func WithParentInfoClientFactory(f func(name string) (traits.ParentInfoClient, e
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterParentInfoServer(server, r)
 }
 

--- a/pkg/trait/ptz/api_router.pb.go
+++ b/pkg/trait/ptz/api_router.pb.go
@@ -35,7 +35,7 @@ func WithPtzApiClientFactory(f func(name string) (traits.PtzApiClient, error)) r
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPtzApiServer(server, r)
 }
 

--- a/pkg/trait/ptz/api_wrap.pb.go
+++ b/pkg/trait/ptz/api_wrap.pb.go
@@ -5,33 +5,39 @@ package ptz
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.PtzApiServer	and presents it as a traits.PtzApiClient
-func WrapApi(server traits.PtzApiServer) traits.PtzApiClient {
+func WrapApi(server traits.PtzApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.PtzApi_ServiceDesc, server)
 	client := traits.NewPtzApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		PtzApiClient: client,
 		server:       server,
+		conn:         conn,
+		desc:         traits.PtzApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.PtzApiClient
 
 	server traits.PtzApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.PtzApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.PtzApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.PtzApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/ptz/info_router.pb.go
+++ b/pkg/trait/ptz/info_router.pb.go
@@ -34,7 +34,7 @@ func WithPtzInfoClientFactory(f func(name string) (traits.PtzInfoClient, error))
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPtzInfoServer(server, r)
 }
 

--- a/pkg/trait/publication/api_router.pb.go
+++ b/pkg/trait/publication/api_router.pb.go
@@ -35,7 +35,7 @@ func WithPublicationApiClientFactory(f func(name string) (traits.PublicationApiC
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPublicationApiServer(server, r)
 }
 

--- a/pkg/trait/publication/api_wrap.pb.go
+++ b/pkg/trait/publication/api_wrap.pb.go
@@ -5,33 +5,39 @@ package publication
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.PublicationApiServer	and presents it as a traits.PublicationApiClient
-func WrapApi(server traits.PublicationApiServer) traits.PublicationApiClient {
+func WrapApi(server traits.PublicationApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.PublicationApi_ServiceDesc, server)
 	client := traits.NewPublicationApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		PublicationApiClient: client,
 		server:               server,
+		conn:                 conn,
+		desc:                 traits.PublicationApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.PublicationApiClient
 
 	server traits.PublicationApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.PublicationApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.PublicationApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.PublicationApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/publication/model_server.go
+++ b/pkg/trait/publication/model_server.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 var VersionMismatchErr = status.Error(codes.FailedPrecondition, "version mismatch: update version != server version")
@@ -29,7 +30,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterPublicationApiServer(server, m)
 }
 

--- a/pkg/trait/speaker/api_router.pb.go
+++ b/pkg/trait/speaker/api_router.pb.go
@@ -36,7 +36,7 @@ func WithSpeakerApiClientFactory(f func(name string) (traits.SpeakerApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterSpeakerApiServer(server, r)
 }
 

--- a/pkg/trait/speaker/api_wrap.pb.go
+++ b/pkg/trait/speaker/api_wrap.pb.go
@@ -5,33 +5,39 @@ package speaker
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.SpeakerApiServer	and presents it as a traits.SpeakerApiClient
-func WrapApi(server traits.SpeakerApiServer) traits.SpeakerApiClient {
+func WrapApi(server traits.SpeakerApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.SpeakerApi_ServiceDesc, server)
 	client := traits.NewSpeakerApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		SpeakerApiClient: client,
 		server:           server,
+		conn:             conn,
+		desc:             traits.SpeakerApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.SpeakerApiClient
 
 	server traits.SpeakerApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.SpeakerApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.SpeakerApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.SpeakerApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/speaker/info_router.pb.go
+++ b/pkg/trait/speaker/info_router.pb.go
@@ -34,7 +34,7 @@ func WithSpeakerInfoClientFactory(f func(name string) (traits.SpeakerInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterSpeakerInfoServer(server, r)
 }
 

--- a/pkg/trait/speaker/info_wrap.pb.go
+++ b/pkg/trait/speaker/info_wrap.pb.go
@@ -5,33 +5,39 @@ package speaker
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.SpeakerInfoServer	and presents it as a traits.SpeakerInfoClient
-func WrapInfo(server traits.SpeakerInfoServer) traits.SpeakerInfoClient {
+func WrapInfo(server traits.SpeakerInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.SpeakerInfo_ServiceDesc, server)
 	client := traits.NewSpeakerInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		SpeakerInfoClient: client,
 		server:            server,
+		conn:              conn,
+		desc:              traits.SpeakerInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.SpeakerInfoClient
 
 	server traits.SpeakerInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.SpeakerInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.SpeakerInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.SpeakerInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/speaker/memory.go
+++ b/pkg/trait/speaker/memory.go
@@ -3,13 +3,15 @@ package speaker
 import (
 	"context"
 
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-api/go/types"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 type MemoryDevice struct {
@@ -23,7 +25,7 @@ func NewMemoryDevice(initialState *types.AudioLevel) *MemoryDevice {
 	}
 }
 
-func (s *MemoryDevice) Register(server *grpc.Server) {
+func (s *MemoryDevice) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterSpeakerApiServer(server, s)
 }
 

--- a/pkg/trait/vending/api_router.pb.go
+++ b/pkg/trait/vending/api_router.pb.go
@@ -35,7 +35,7 @@ func WithVendingApiClientFactory(f func(name string) (traits.VendingApiClient, e
 	})
 }
 
-func (r *ApiRouter) Register(server *grpc.Server) {
+func (r *ApiRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterVendingApiServer(server, r)
 }
 

--- a/pkg/trait/vending/api_wrap.pb.go
+++ b/pkg/trait/vending/api_wrap.pb.go
@@ -5,33 +5,39 @@ package vending
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapApi	adapts a traits.VendingApiServer	and presents it as a traits.VendingApiClient
-func WrapApi(server traits.VendingApiServer) traits.VendingApiClient {
+func WrapApi(server traits.VendingApiServer) *ApiWrapper {
 	conn := wrap.ServerToClient(traits.VendingApi_ServiceDesc, server)
 	client := traits.NewVendingApiClient(conn)
-	return &apiWrapper{
+	return &ApiWrapper{
 		VendingApiClient: client,
 		server:           server,
+		conn:             conn,
+		desc:             traits.VendingApi_ServiceDesc,
 	}
 }
 
-type apiWrapper struct {
+type ApiWrapper struct {
 	traits.VendingApiClient
 
 	server traits.VendingApiServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.VendingApiClient = (*apiWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *apiWrapper) UnwrapServer() traits.VendingApiServer {
+func (w *ApiWrapper) UnwrapServer() traits.VendingApiServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *apiWrapper) Unwrap() any {
+func (w *ApiWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *ApiWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/vending/info_router.pb.go
+++ b/pkg/trait/vending/info_router.pb.go
@@ -33,7 +33,7 @@ func WithVendingInfoClientFactory(f func(name string) (traits.VendingInfoClient,
 	})
 }
 
-func (r *InfoRouter) Register(server *grpc.Server) {
+func (r *InfoRouter) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterVendingInfoServer(server, r)
 }
 

--- a/pkg/trait/vending/info_wrap.pb.go
+++ b/pkg/trait/vending/info_wrap.pb.go
@@ -5,33 +5,39 @@ package vending
 import (
 	traits "github.com/smart-core-os/sc-api/go/traits"
 	wrap "github.com/smart-core-os/sc-golang/pkg/wrap"
+	grpc "google.golang.org/grpc"
 )
 
 // WrapInfo	adapts a traits.VendingInfoServer	and presents it as a traits.VendingInfoClient
-func WrapInfo(server traits.VendingInfoServer) traits.VendingInfoClient {
+func WrapInfo(server traits.VendingInfoServer) *InfoWrapper {
 	conn := wrap.ServerToClient(traits.VendingInfo_ServiceDesc, server)
 	client := traits.NewVendingInfoClient(conn)
-	return &infoWrapper{
+	return &InfoWrapper{
 		VendingInfoClient: client,
 		server:            server,
+		conn:              conn,
+		desc:              traits.VendingInfo_ServiceDesc,
 	}
 }
 
-type infoWrapper struct {
+type InfoWrapper struct {
 	traits.VendingInfoClient
 
 	server traits.VendingInfoServer
+	conn   grpc.ClientConnInterface
+	desc   grpc.ServiceDesc
 }
 
-// compile time check that we implement the interface we need
-var _ traits.VendingInfoClient = (*infoWrapper)(nil)
-
 // UnwrapServer returns the underlying server instance.
-func (w *infoWrapper) UnwrapServer() traits.VendingInfoServer {
+func (w *InfoWrapper) UnwrapServer() traits.VendingInfoServer {
 	return w.server
 }
 
 // Unwrap implements wrap.Unwrapper and returns the underlying server instance as an unknown type.
-func (w *infoWrapper) Unwrap() any {
+func (w *InfoWrapper) Unwrap() any {
 	return w.UnwrapServer()
+}
+
+func (w *InfoWrapper) UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc) {
+	return w.conn, w.desc
 }

--- a/pkg/trait/vending/model_server.go
+++ b/pkg/trait/vending/model_server.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sort"
 
-	"github.com/smart-core-os/sc-api/go/traits"
-	"github.com/smart-core-os/sc-api/go/types"
-	"github.com/smart-core-os/sc-golang/pkg/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 // ModelServer adapts a Model to implement traits.VendingApiServer.
@@ -27,7 +28,7 @@ func (m *ModelServer) Unwrap() any {
 	return m.model
 }
 
-func (m *ModelServer) Register(server *grpc.Server) {
+func (m *ModelServer) Register(server grpc.ServiceRegistrar) {
 	traits.RegisterVendingApiServer(server, m)
 }
 

--- a/pkg/wrap/unwrap.go
+++ b/pkg/wrap/unwrap.go
@@ -1,8 +1,16 @@
 package wrap
 
+import (
+	"google.golang.org/grpc"
+)
+
 // Unwrapper defines the Unwrap method for exposing underlying implementation types.
 type Unwrapper interface {
 	Unwrap() any
+}
+
+type ServiceUnwrapper interface {
+	UnwrapService() (grpc.ClientConnInterface, grpc.ServiceDesc)
 }
 
 // UnwrapFully repeatedly casts then unwraps obj until obj no longer implements Unwrapper.

--- a/pkg/wrap/wrap.go
+++ b/pkg/wrap/wrap.go
@@ -86,7 +86,7 @@ func (w *wrapper) Invoke(ctx context.Context, method string, args any, reply any
 	return err
 }
 
-func (w *wrapper) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+func (w *wrapper) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 	matched, ok := w.streams[method]
 	if !ok {
 		if matchedMethod, ok := w.methods[method]; ok {

--- a/pkg/wrap/wrap_test.go
+++ b/pkg/wrap/wrap_test.go
@@ -103,6 +103,12 @@ func TestWrapper_UnaryAsStream(t *testing.T) {
 	if diff := cmp.Diff(expectMD, md); diff != "" {
 		t.Errorf("stream.Header() mismatch (-want +got):\n%s", diff)
 	}
+
+	// stream should be closed now, because unary calls send only one response
+	err = stream.RecvMsg(res)
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("stream not closed - expected EOF, got %v", err)
+	}
 }
 
 // tests that the wrapper passes server-streaming calls through correctly, including metadata


### PR DESCRIPTION
A set of miscellaneous changes intended to be read together with [sc-bos#283](https://github.com/vanti-dev/sc-bos/pull/283).

 - use `grpc.ServiceRegistrar` instead of `*grpc.Server` where possible, to allow alternative impelementations.
 - Change wrappers to allow unwrapping the client conn - to enable graceful migration to new way of proxying
 - add `metadata.CollectionModel` & `metadata.CollectionServer` that stores metadata for multiple devices in a single `resource.Collection`.
 - support invoking unary RPCs using `NewStream` - useful for dynamic proxying where the distinction between unary and streaming RPCs is lost
 - resource: `WithIDInterceptor` allows mapping all collection IDs through a user-supplied function