### PR TITLE
trait/openclose: add model support for presets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/mennanov/fmutils v0.1.1
-	github.com/smart-core-os/sc-api/go v1.0.0-beta.46
+	github.com/smart-core-os/sc-api/go v1.0.0-beta.48
 	github.com/tanema/gween v0.0.0-20200427131925-c89ae23cc63c
 	go.uber.org/zap v1.17.0
 	golang.org/x/exp v0.0.0-20240822175202-778ce7bba035

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/smart-core-os/sc-api/go v1.0.0-beta.46 h1:RgQn+FHnEYpAY1+oL+ILHVXix19yX/BLykA86ovhH7I=
-github.com/smart-core-os/sc-api/go v1.0.0-beta.46/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
+github.com/smart-core-os/sc-api/go v1.0.0-beta.48 h1:d8BmKJIBFNi5t/poBSQYeRKt7n7GOqe7POvKmohkB+s=
+github.com/smart-core-os/sc-api/go v1.0.0-beta.48/go.mod h1:HpHbz0skS27690VbVGBFA+tiNyEkNlZP5p68MUREIJY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/pkg/resource/opt.go
+++ b/pkg/resource/opt.go
@@ -28,6 +28,15 @@ type EmptyOption struct {
 func (e EmptyOption) apply(_ *config) {
 }
 
+// Options converts a []Option to an Option.
+type Options []Option
+
+func (o Options) apply(c *config) {
+	for _, option := range o {
+		option.apply(c)
+	}
+}
+
 // WithClock configures the clock used when time is needed.
 // Defaults to a Clock backed by the time package.
 func WithClock(c Clock) Option {

--- a/pkg/resource/opt.go
+++ b/pkg/resource/opt.go
@@ -28,15 +28,6 @@ type EmptyOption struct {
 func (e EmptyOption) apply(_ *config) {
 }
 
-// Options converts a []Option to an Option.
-type Options []Option
-
-func (o Options) apply(c *config) {
-	for _, option := range o {
-		option.apply(c)
-	}
-}
-
 // WithClock configures the clock used when time is needed.
 // Defaults to a Clock backed by the time package.
 func WithClock(c Clock) Option {

--- a/pkg/trait/openclose/model.go
+++ b/pkg/trait/openclose/model.go
@@ -22,6 +22,8 @@ type Model struct {
 	presets   []preset
 }
 
+// NewModel creates a new *Model with the given options.
+// Options are applied to all resource types in the model unless specified otherwise in the option.
 func NewModel(opts ...resource.Option) *Model {
 	args := calcModelArgs(opts...)
 	return &Model{

--- a/pkg/trait/openclose/model.go
+++ b/pkg/trait/openclose/model.go
@@ -53,10 +53,10 @@ func (m *Model) GetPositions(opts ...resource.ReadOption) (*traits.OpenClosePosi
 	return dst, nil
 }
 
-func (m *Model) GetPosition(id traits.OpenClosePosition_Direction, opts ...resource.ReadOption) (*traits.OpenClosePosition, error) {
-	position, ok := m.positions.Get(directionToID(id), opts...)
+func (m *Model) GetPosition(dir traits.OpenClosePosition_Direction, opts ...resource.ReadOption) (*traits.OpenClosePosition, error) {
+	position, ok := m.positions.Get(directionToID(dir), opts...)
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "position %v not found", id)
+		return nil, status.Errorf(codes.NotFound, "position %v not found", dir)
 	}
 	return position.(*traits.OpenClosePosition), nil
 }
@@ -92,8 +92,8 @@ func (m *Model) UpdatePosition(position *traits.OpenClosePosition, opts ...resou
 	return m.UpdatePositionN(position.Direction, position, opts...)
 }
 
-func (m *Model) UpdatePositionN(id traits.OpenClosePosition_Direction, position *traits.OpenClosePosition, opts ...resource.WriteOption) (*traits.OpenClosePosition, error) {
-	msg, err := m.positions.Update(directionToID(id), position, opts...)
+func (m *Model) UpdatePositionN(dir traits.OpenClosePosition_Direction, position *traits.OpenClosePosition, opts ...resource.WriteOption) (*traits.OpenClosePosition, error) {
+	msg, err := m.positions.Update(directionToID(dir), position, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/trait/openclose/model.go
+++ b/pkg/trait/openclose/model.go
@@ -2,12 +2,14 @@ package openclose
 
 import (
 	"context"
-	"sort"
-	"strconv"
+	"fmt"
+	"slices"
 	"time"
 
+	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/cmp"
@@ -17,34 +19,58 @@ import (
 
 type Model struct {
 	positions *resource.Collection // of *traits.OpenClosePosition
+	presets   []preset
 }
 
 func NewModel(opts ...resource.Option) *Model {
+	args := calcModelArgs(opts...)
 	return &Model{
-		positions: resource.NewCollection(opts...),
+		positions: resource.NewCollection(args.positionsOpts...),
+		presets:   args.presets,
 	}
 }
 
+// preset describes a proto preset combined with the positions applied when activating that preset.
+type preset struct {
+	desc      *traits.OpenClosePositions_Preset
+	positions []*traits.OpenClosePosition
+}
+
 func (m *Model) GetPositions(opts ...resource.ReadOption) (*traits.OpenClosePositions, error) {
-	allPositions := m.positions.List(opts...)
+	allPositions := m.positions.List(opts...) // already sorted by ID aka Direction ordinal
 	dst := &traits.OpenClosePositions{
 		States: make([]*traits.OpenClosePosition, len(allPositions)),
 	}
 	for i, position := range allPositions {
 		dst.States[i] = position.(*traits.OpenClosePosition)
 	}
+
+	preset, _ := m.presetForValue(dst.States)
+	if preset != nil {
+		dst.Preset = preset
+	}
+
 	return dst, nil
 }
 
-func (m *Model) GetPosition(id string, opts ...resource.ReadOption) (*traits.OpenClosePosition, error) {
-	position, ok := m.positions.Get(id, opts...)
+func (m *Model) GetPosition(id traits.OpenClosePosition_Direction, opts ...resource.ReadOption) (*traits.OpenClosePosition, error) {
+	position, ok := m.positions.Get(directionToID(id), opts...)
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "position %s not found", id)
+		return nil, status.Errorf(codes.NotFound, "position %v not found", id)
 	}
 	return position.(*traits.OpenClosePosition), nil
 }
 
 func (m *Model) UpdatePositions(positions *traits.OpenClosePositions, opts ...resource.WriteOption) (*traits.OpenClosePositions, error) {
+	// preset handling
+	if positions.Preset != nil {
+		preset, presetPositions := m.presetForName(positions.Preset.Name)
+		if preset == nil {
+			return nil, status.Errorf(codes.InvalidArgument, "preset %q not found", positions.Preset.Name)
+		}
+		positions.States = presetPositions
+	}
+
 	writeRequest := resource.ComputeWriteConfig(opts...)
 	opts = append([]resource.WriteOption{}, opts...)
 	if writeRequest.UpdateMask != nil {
@@ -52,8 +78,8 @@ func (m *Model) UpdatePositions(positions *traits.OpenClosePositions, opts ...re
 	}
 	opts = append(opts, resource.WithCreateIfAbsent())
 
-	for i, state := range positions.States {
-		_, err := m.positions.Update(strconv.Itoa(i), state, opts...)
+	for _, state := range positions.States {
+		_, err := m.positions.Update(directionToID(state.Direction), state, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -63,11 +89,11 @@ func (m *Model) UpdatePositions(positions *traits.OpenClosePositions, opts ...re
 }
 
 func (m *Model) UpdatePosition(position *traits.OpenClosePosition, opts ...resource.WriteOption) (*traits.OpenClosePosition, error) {
-	return m.UpdatePositionN(0, position, opts...)
+	return m.UpdatePositionN(position.Direction, position, opts...)
 }
 
-func (m *Model) UpdatePositionN(id uint, position *traits.OpenClosePosition, opts ...resource.WriteOption) (*traits.OpenClosePosition, error) {
-	msg, err := m.positions.Update(strconv.Itoa(int(id)), position, opts...)
+func (m *Model) UpdatePositionN(id traits.OpenClosePosition_Direction, position *traits.OpenClosePosition, opts ...resource.WriteOption) (*traits.OpenClosePosition, error) {
+	msg, err := m.positions.Update(directionToID(id), position, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -103,18 +129,11 @@ func (m *Model) PullPositions(ctx context.Context, ops ...resource.ReadOption) <
 
 			// transform into the correct output format
 			positions := &traits.OpenClosePositions{
-				States: make([]*traits.OpenClosePosition, len(all)),
+				States: maps.Values(all),
 			}
-			order := make([]string, len(all))
-			i := 0
-			for id := range all {
-				order[i] = id
-				i++
-			}
-			sort.Strings(order)
-			for i, id := range order {
-				positions.States[i] = all[id]
-			}
+			sortPositions(positions.States)
+
+			positions.Preset, _ = m.presetForValue(positions.States)
 
 			// projection and filtering
 			responseFilter.Filter(positions)
@@ -140,4 +159,45 @@ func (m *Model) PullPositions(ctx context.Context, ops ...resource.ReadOption) <
 type PullOpenClosePositionsChange struct {
 	Positions  *traits.OpenClosePositions
 	ChangeTime time.Time
+}
+
+func (m *Model) ListPresets() []*traits.OpenClosePositions_Preset {
+	presets := make([]*traits.OpenClosePositions_Preset, len(m.presets))
+	for i, preset := range m.presets {
+		presets[i] = preset.desc
+	}
+	return presets
+}
+
+func (m *Model) HasPreset(name string) bool {
+	n, _ := m.presetForName(name)
+	return n != nil
+}
+
+func (m *Model) presetForName(name string) (*traits.OpenClosePositions_Preset, []*traits.OpenClosePosition) {
+	for _, preset := range m.presets {
+		if preset.desc.Name == name {
+			return preset.desc, preset.positions
+		}
+	}
+	return nil, nil
+}
+
+func (m *Model) presetForValue(value []*traits.OpenClosePosition) (*traits.OpenClosePositions_Preset, []*traits.OpenClosePosition) {
+	for _, preset := range m.presets {
+		if proto.Equal(&traits.OpenClosePositions{States: preset.positions}, &traits.OpenClosePositions{States: value}) {
+			return preset.desc, preset.positions
+		}
+	}
+	return nil, nil
+}
+
+func directionToID(direction traits.OpenClosePosition_Direction) string {
+	// if the number of directions ever exceeds 99 we need to change this
+	return fmt.Sprintf("%02d", direction)
+}
+func sortPositions(ps []*traits.OpenClosePosition) {
+	slices.SortFunc(ps, func(a, b *traits.OpenClosePosition) int {
+		return int(a.Direction - b.Direction)
+	})
 }

--- a/pkg/trait/openclose/model_opts.go
+++ b/pkg/trait/openclose/model_opts.go
@@ -1,8 +1,6 @@
 package openclose
 
 import (
-	"strconv"
-
 	"github.com/smart-core-os/sc-api/go/traits"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
@@ -23,8 +21,8 @@ func WithOpenClosePositionsOption(opts ...resource.Option) resource.Option {
 // This option should only be used once per model.
 func WithInitialOpenClosePositions(positions ...*traits.OpenClosePosition) resource.Option {
 	var opts []resource.Option
-	for i, state := range positions {
-		opts = append(opts, resource.WithInitialRecord(strconv.Itoa(i), state))
+	for _, state := range positions {
+		opts = append(opts, resource.WithInitialRecord(directionToID(state.Direction), state))
 	}
 	return WithOpenClosePositionsOption(opts...)
 }

--- a/pkg/trait/openclose/model_opts.go
+++ b/pkg/trait/openclose/model_opts.go
@@ -10,14 +10,14 @@ var DefaultModelOptions = []resource.Option{
 	WithInitialPositions(), // no positions
 }
 
-// WithPositionsOption configures the positions resource of the model.
+// WithPositionsOption configures options for the position resource.
 func WithPositionsOption(opts ...resource.Option) resource.Option {
 	return modelOptionFunc(func(args *modelArgs) {
 		args.positionsOpts = append(args.positionsOpts, opts...)
 	})
 }
 
-// WithInitialPositions returns an option that configures the model to initialise with the given positions.
+// WithInitialPositions returns an option that configures the positions resource to initialise with the given positions.
 // This option should only be used once per model.
 func WithInitialPositions(positions ...*traits.OpenClosePosition) resource.Option {
 	var opts []resource.Option
@@ -28,6 +28,7 @@ func WithInitialPositions(positions ...*traits.OpenClosePosition) resource.Optio
 }
 
 // WithPreset returns an option that configures the model with the given preset.
+// This option does not apply to any resource.
 func WithPreset(desc *traits.OpenClosePositions_Preset, positions ...*traits.OpenClosePosition) resource.Option {
 	sortPositions(positions)
 	return modelOptionFunc(func(args *modelArgs) {

--- a/pkg/trait/openclose/model_opts.go
+++ b/pkg/trait/openclose/model_opts.go
@@ -12,12 +12,6 @@ var DefaultModelOptions = []resource.Option{
 	WithInitialOpenClosePositions(), // no positions
 }
 
-// ModelOption defined the base type for all options that apply to this traits model.
-type ModelOption interface {
-	resource.Option
-	applyModel(args *modelArgs)
-}
-
 // WithOpenClosePositionsOption configures the positions resource of the model.
 func WithOpenClosePositionsOption(opts ...resource.Option) resource.Option {
 	return modelOptionFunc(func(args *modelArgs) {
@@ -57,7 +51,7 @@ type modelArgs struct {
 
 func (a *modelArgs) apply(opts ...resource.Option) {
 	for _, opt := range opts {
-		if v, ok := opt.(ModelOption); ok {
+		if v, ok := opt.(modelOption); ok {
 			v.applyModel(a)
 			continue
 		}
@@ -65,7 +59,7 @@ func (a *modelArgs) apply(opts ...resource.Option) {
 	}
 }
 
-func modelOptionFunc(fn func(args *modelArgs)) ModelOption {
+func modelOptionFunc(fn func(args *modelArgs)) modelOption {
 	return modelOption{resource.EmptyOption{}, fn}
 }
 

--- a/pkg/trait/openclose/model_opts.go
+++ b/pkg/trait/openclose/model_opts.go
@@ -1,0 +1,79 @@
+package openclose
+
+import (
+	"strconv"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-golang/pkg/resource"
+)
+
+// DefaultModelOptions holds the default options for the model.
+var DefaultModelOptions = []resource.Option{
+	WithInitialOpenClosePositions(), // no positions
+}
+
+// ModelOption defined the base type for all options that apply to this traits model.
+type ModelOption interface {
+	resource.Option
+	applyModel(args *modelArgs)
+}
+
+// WithOpenClosePositionsOption configures the positions resource of the model.
+func WithOpenClosePositionsOption(opts ...resource.Option) resource.Option {
+	return modelOptionFunc(func(args *modelArgs) {
+		args.positionsOpts = append(args.positionsOpts, opts...)
+	})
+}
+
+// WithInitialOpenClosePositions returns an option that configures the model to initialise with the given positions.
+// This option should only be used once per model.
+func WithInitialOpenClosePositions(positions ...*traits.OpenClosePosition) resource.Option {
+	var opts []resource.Option
+	for i, state := range positions {
+		opts = append(opts, resource.WithInitialRecord(strconv.Itoa(i), state))
+	}
+	return WithOpenClosePositionsOption(resource.Options(opts))
+}
+
+// WithPreset returns an option that configures the model with the given preset.
+func WithPreset(desc *traits.OpenClosePositions_Preset, positions ...*traits.OpenClosePosition) resource.Option {
+	sortPositions(positions)
+	return modelOptionFunc(func(args *modelArgs) {
+		args.presets = append(args.presets, preset{desc: desc, positions: positions})
+	})
+}
+
+func calcModelArgs(opts ...resource.Option) modelArgs {
+	args := new(modelArgs)
+	args.apply(DefaultModelOptions...)
+	args.apply(opts...)
+	return *args
+}
+
+type modelArgs struct {
+	positionsOpts []resource.Option
+	presets       []preset
+}
+
+func (a *modelArgs) apply(opts ...resource.Option) {
+	for _, opt := range opts {
+		if v, ok := opt.(ModelOption); ok {
+			v.applyModel(a)
+			continue
+		}
+		a.positionsOpts = append(a.positionsOpts, opt)
+	}
+}
+
+func modelOptionFunc(fn func(args *modelArgs)) ModelOption {
+	return modelOption{resource.EmptyOption{}, fn}
+}
+
+type modelOption struct {
+	resource.Option
+	fn func(args *modelArgs)
+}
+
+func (m modelOption) applyModel(args *modelArgs) {
+	m.fn(args)
+}

--- a/pkg/trait/openclose/model_opts.go
+++ b/pkg/trait/openclose/model_opts.go
@@ -7,24 +7,24 @@ import (
 
 // DefaultModelOptions holds the default options for the model.
 var DefaultModelOptions = []resource.Option{
-	WithInitialOpenClosePositions(), // no positions
+	WithInitialPositions(), // no positions
 }
 
-// WithOpenClosePositionsOption configures the positions resource of the model.
-func WithOpenClosePositionsOption(opts ...resource.Option) resource.Option {
+// WithPositionsOption configures the positions resource of the model.
+func WithPositionsOption(opts ...resource.Option) resource.Option {
 	return modelOptionFunc(func(args *modelArgs) {
 		args.positionsOpts = append(args.positionsOpts, opts...)
 	})
 }
 
-// WithInitialOpenClosePositions returns an option that configures the model to initialise with the given positions.
+// WithInitialPositions returns an option that configures the model to initialise with the given positions.
 // This option should only be used once per model.
-func WithInitialOpenClosePositions(positions ...*traits.OpenClosePosition) resource.Option {
+func WithInitialPositions(positions ...*traits.OpenClosePosition) resource.Option {
 	var opts []resource.Option
 	for _, state := range positions {
 		opts = append(opts, resource.WithInitialRecord(directionToID(state.Direction), state))
 	}
-	return WithOpenClosePositionsOption(opts...)
+	return WithPositionsOption(opts...)
 }
 
 // WithPreset returns an option that configures the model with the given preset.

--- a/pkg/trait/openclose/model_opts.go
+++ b/pkg/trait/openclose/model_opts.go
@@ -26,7 +26,7 @@ func WithInitialOpenClosePositions(positions ...*traits.OpenClosePosition) resou
 	for i, state := range positions {
 		opts = append(opts, resource.WithInitialRecord(strconv.Itoa(i), state))
 	}
-	return WithOpenClosePositionsOption(resource.Options(opts))
+	return WithOpenClosePositionsOption(opts...)
 }
 
 // WithPreset returns an option that configures the model with the given preset.

--- a/pkg/trait/openclose/model_server.go
+++ b/pkg/trait/openclose/model_server.go
@@ -7,11 +7,13 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/smart-core-os/sc-api/go/traits"
+	"github.com/smart-core-os/sc-api/go/types"
 	"github.com/smart-core-os/sc-golang/pkg/resource"
 )
 
 type ModelServer struct {
 	traits.UnimplementedOpenCloseApiServer
+	traits.UnimplementedOpenCloseInfoServer
 	model *Model
 }
 
@@ -47,4 +49,16 @@ func (s *ModelServer) PullPositions(request *traits.PullOpenClosePositionsReques
 		}
 	}
 	return nil
+}
+
+func (s *ModelServer) DescribePositions(_ context.Context, _ *traits.DescribePositionsRequest) (*traits.PositionsSupport, error) {
+	support := &traits.PositionsSupport{
+		ResourceSupport: &types.ResourceSupport{
+			Readable: true, Writable: true, Observable: true,
+			PullSupport: types.PullSupport_PULL_SUPPORT_NATIVE,
+		},
+		SupportsStop: true,
+		Presets:      s.model.ListPresets(),
+	}
+	return support, nil
 }


### PR DESCRIPTION
This includes support for the OpenCloseInfo aspect as part of the model and model server.