### PR TITLE
traits/mode: add info server model

### DIFF
--- a/pkg/trait/modepb/infoserver.go
+++ b/pkg/trait/modepb/infoserver.go
@@ -1,0 +1,16 @@
+package modepb
+
+import (
+	"context"
+
+	"github.com/smart-core-os/sc-api/go/traits"
+)
+
+type InfoServer struct {
+	traits.UnimplementedModeInfoServer
+	Modes *traits.ModesSupport
+}
+
+func (i *InfoServer) DescribeModes(context.Context, *traits.DescribeModesRequest) (*traits.ModesSupport, error) {
+	return i.Modes, nil
+}


### PR DESCRIPTION
move the mode info model server from https://github.com/vanti-dev/sc-bos/blob/main/pkg/gentrait/modepb/info.go to this repo